### PR TITLE
[1.16.3] Adds overloads of the compat methods to allow for two mod id's

### DIFF
--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
@@ -226,6 +226,7 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	 * Creates and registers a compat {@link Block}
 	 *
 	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param modId2   - The mod id of the second mod this block is compatible for, set to "indev" for dev tests (optional)
 	 * @param name     - The block's name
 	 * @param supplier - The supplied {@link Block}
 	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
@@ -236,11 +237,19 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
 		return block;
 	}
+	
+	public <B extends Block> RegistryObject<B> createCompatBlock(String modId, String modId2, String name, Supplier<? extends B> supplier, @Nullable ItemGroup group) {
+		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
+		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;
+		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(determinedGroup)));
+		return block;
+	}
 
 	/**
 	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
 	 *
-	 * @param modId    - The modId of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param modId2   - The mod id of the second mod this block is compatible for, set to "indev" for dev tests (optional)
 	 * @param name     - The block's name
 	 * @param supplier - The supplied {@link Block}
 	 * @param burnTime - How many ticks this fuel block should burn for.
@@ -250,6 +259,13 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String modId, String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group) {
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
 		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		return block;
+	}
+	
+	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String modId, String modId2, String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group) {
+		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
+		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;
+		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(determinedGroup)));
 		return block;
 	}
 

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
@@ -228,6 +228,21 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		this.itemRegister.register(name + "_sign", () -> new AbnormalsSignItem(standing.get(), wall.get(), new Item.Properties().maxStackSize(16).group(ItemGroup.DECORATIONS)));
 		return Pair.of(standing, wall);
 	}
+	
+	/**
+	 * Creates and registers a compat {@link Block}
+	 *
+	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param name     - The block's name
+	 * @param supplier - The supplied {@link Block}
+	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
+	 * @return A {@link RegistryObject} containing the created {@link Block}
+	 */
+	public <B extends Block> RegistryObject<B> createCompatBlock(String modId, String name, Supplier<? extends B> supplier, @Nullable ItemGroup group) {
+		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
+		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		return block;
+	}
 
 	/**
 	 * Creates and registers a compat {@link Block}
@@ -240,15 +255,30 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	 */
 	public <B extends Block> RegistryObject<B> createCompatBlock(String name, Supplier<? extends B> supplier, @Nullable ItemGroup group, String ...modIdList) {
 		boolean areModsLoaded = true;
-		if (FMLEnvironment.production)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
+		for (String mod : modIdList)
+			areModsLoaded &= ModList.get().isLoaded(mod);
 		ItemGroup determinedGroup = areModsLoaded ? group : null;
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
 		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(determinedGroup)));
 		return block;
 	}
 
+	/**
+	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
+	 *
+	 * @param modId    - The modId of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param name     - The block's name
+	 * @param supplier - The supplied {@link Block}
+	 * @param burnTime - How many ticks this fuel block should burn for.
+	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
+	 * @return A {@link RegistryObject} containing the created {@link Block}
+	 */
+	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String modId, String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group) {
+		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
+		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		return block;
+	}
+	
 	/**
 	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
 	 *
@@ -261,13 +291,34 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	 */
 	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group, String ...modIdList) {
 		boolean areModsLoaded = true;
-		if (FMLEnvironment.production)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
+		for (String mod : modIdList)
+			areModsLoaded &= ModList.get().isLoaded(mod);
 		ItemGroup determinedGroup = areModsLoaded ? group : null;
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
 		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(determinedGroup)));
 		return block;
+	}
+	
+	/**
+	 * Creates and registers a {@link AbnormalsChestBlock} and a {@link AbnormalsTrappedChestBlock} with their {@link FuelBlockItem}s.
+	 *
+	 * @param name        - The name for the chest blocks
+	 * @param compatModId - The mod id of the mod these chests are compatible for.
+	 * @param color       - The {@link MaterialColor} for the chest blocks.
+	 * @return A {@link Pair} containing {@link RegistryObject}s of the {@link AbnormalsChestBlock} and the {@link AbnormalsTrappedChestBlock}
+	 */
+	public Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> createCompatChestBlocks(String name, String compatModId, MaterialColor color) {
+		boolean isModLoaded = ModList.get().isLoaded(compatModId) || compatModId == "indev";
+		ItemGroup chestGroup = isModLoaded ? ItemGroup.DECORATIONS : null;
+		ItemGroup trappedChestGroup = isModLoaded ? ItemGroup.REDSTONE : null;
+		String modId = this.parent.getModId();
+		String chestName = name + "_chest";
+		String trappedChestName = name + "_trapped_chest";
+		RegistryObject<AbnormalsChestBlock> chest = this.deferredRegister.register(chestName, () -> new AbnormalsChestBlock(modId, name, Block.Properties.create(Material.WOOD, color).hardnessAndResistance(2.5F).sound(SoundType.WOOD)));
+		RegistryObject<AbnormalsTrappedChestBlock> trappedChest = this.deferredRegister.register(trappedChestName, () -> new AbnormalsTrappedChestBlock(modId, name, Block.Properties.create(Material.WOOD, color).hardnessAndResistance(2.5F).sound(SoundType.WOOD)));
+		this.itemRegister.register(chestName, () -> new BlockItem(chest.get(), new Item.Properties().group(chestGroup).setISTER(() -> chestISTER(false))));
+		this.itemRegister.register(trappedChestName, () -> new BlockItem(trappedChest.get(), new Item.Properties().group(trappedChestGroup).setISTER(() -> chestISTER(true))));
+		return Pair.of(chest, trappedChest);
 	}
 
 	/**
@@ -280,9 +331,8 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	 */
 	public Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> createCompatChestBlocks(String name, MaterialColor color, String ...modIdList) {
 		boolean areModsLoaded = true;
-		if (FMLEnvironment.production)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
+		for (String mod : modIdList)
+			areModsLoaded &= ModList.get().isLoaded(mod);
 		ItemGroup chestGroup = areModsLoaded ? ItemGroup.DECORATIONS : null;
 		ItemGroup trappedChestGroup = areModsLoaded ? ItemGroup.REDSTONE : null;
 		String modId = this.parent.getModId();

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
@@ -1,11 +1,5 @@
 package com.teamabnormals.abnormals_core.core.util.registry;
 
-import java.util.ArrayList;
-import java.util.concurrent.Callable;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.mojang.datafixers.util.Pair;
 import com.teamabnormals.abnormals_core.client.renderer.ChestItemRenderer;
 import com.teamabnormals.abnormals_core.common.blocks.chest.AbnormalsChestBlock;
@@ -37,6 +31,10 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 /**
  * A basic {@link AbstractSubRegistryHelper} for blocks. This contains some useful registering methods for blocks.
@@ -244,27 +242,6 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
 		return block;
 	}
-	
-	/**
-	 * Creates and registers a compat {@link Block}
-	 *
-	 * @param modIdList - The ArrayList of all the mod ids this block is compatible for
-	 * @param isIndev   - Set to true for dev tests
-	 * @param name      - The block's name
-	 * @param supplier  - The supplied {@link Block}
-	 * @param group     - The {@link ItemGroup} for the {@link BlockItem}
-	 * @return A {@link RegistryObject} containing the created {@link Block}
-	 */
-	public <B extends Block> RegistryObject<B> createCompatBlock(ArrayList<String> modIdList, boolean isIndev, String name, Supplier<? extends B> supplier, @Nullable ItemGroup group) {
-		boolean areModsLoaded = true;
-		if (!isIndev)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
-		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
-		ItemGroup determinedGroup = areModsLoaded ? group : null;
-		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(determinedGroup)));
-		return block;
-	}
 
 	/**
 	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
@@ -281,28 +258,6 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
 		return block;
 	}
-	
-	/**
-	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
-	 *
-	 * @param modIdList - The ArrayList of all the mod ids this block is compatible for
-	 * @param isIndev   - Set to true for dev tests
-	 * @param name      - The block's name
-	 * @param supplier  - The supplied {@link Block}
-	 * @param burnTime  - How many ticks this fuel block should burn for.
-	 * @param group     - The {@link ItemGroup} for the {@link BlockItem}
-	 * @return A {@link RegistryObject} containing the created {@link Block}
-	 */
-	public <B extends Block> RegistryObject<B> createCompatFuelBlock(ArrayList<String> modIdList, boolean isIndev, String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group) {
-		boolean areModsLoaded = true;
-		if (!isIndev)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
-		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
-		ItemGroup determinedGroup = areModsLoaded ? group : null;
-		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(determinedGroup)));
-		return block;
-	}
 
 	/**
 	 * Creates and registers a {@link AbnormalsChestBlock} and a {@link AbnormalsTrappedChestBlock} with their {@link FuelBlockItem}s.
@@ -316,32 +271,6 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		boolean isModLoaded = ModList.get().isLoaded(compatModId) || compatModId == "indev";
 		ItemGroup chestGroup = isModLoaded ? ItemGroup.DECORATIONS : null;
 		ItemGroup trappedChestGroup = isModLoaded ? ItemGroup.REDSTONE : null;
-		String modId = this.parent.getModId();
-		String chestName = name + "_chest";
-		String trappedChestName = name + "_trapped_chest";
-		RegistryObject<AbnormalsChestBlock> chest = this.deferredRegister.register(chestName, () -> new AbnormalsChestBlock(modId, name, Block.Properties.create(Material.WOOD, color).hardnessAndResistance(2.5F).sound(SoundType.WOOD)));
-		RegistryObject<AbnormalsTrappedChestBlock> trappedChest = this.deferredRegister.register(trappedChestName, () -> new AbnormalsTrappedChestBlock(modId, name, Block.Properties.create(Material.WOOD, color).hardnessAndResistance(2.5F).sound(SoundType.WOOD)));
-		this.itemRegister.register(chestName, () -> new BlockItem(chest.get(), new Item.Properties().group(chestGroup).setISTER(() -> chestISTER(false))));
-		this.itemRegister.register(trappedChestName, () -> new BlockItem(trappedChest.get(), new Item.Properties().group(trappedChestGroup).setISTER(() -> chestISTER(true))));
-		return Pair.of(chest, trappedChest);
-	}
-	
-	/**
-	 * Creates and registers a {@link AbnormalsChestBlock} and a {@link AbnormalsTrappedChestBlock} with their {@link FuelBlockItem}s.
-	 *
-	 * @param modIdList   - The ArrayList of all the mod ids this block is compatible for
-	 * @param isIndev     - Set to true for indev tests
-	 * @param name        - The name for the chest blocks
-	 * @param color       - The {@link MaterialColor} for the chest blocks.
-	 * @return A {@link Pair} containing {@link RegistryObject}s of the {@link AbnormalsChestBlock} and the {@link AbnormalsTrappedChestBlock}
-	 */
-	public Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> createCompatChestBlock(ArrayList<String> modIdList, boolean isIndev, String name, MaterialColor color) {
-		boolean areModsLoaded = true;
-		if (!isIndev)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
-		ItemGroup chestGroup = areModsLoaded ? ItemGroup.DECORATIONS : null;
-		ItemGroup trappedChestGroup = areModsLoaded ? ItemGroup.REDSTONE : null;
 		String modId = this.parent.getModId();
 		String chestName = name + "_chest";
 		String trappedChestName = name + "_trapped_chest";

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
@@ -29,6 +29,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -231,46 +232,59 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	/**
 	 * Creates and registers a compat {@link Block}
 	 *
-	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
-	 * @param name     - The block's name
-	 * @param supplier - The supplied {@link Block}
-	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
+	 * @param name      - The block's name
+	 * @param supplier  - The supplied {@link Block}
+	 * @param group     - The {@link ItemGroup} for the {@link BlockItem}
+	 * @param modIdList - The mod ids of the mods this block is compatible for
 	 * @return A {@link RegistryObject} containing the created {@link Block}
 	 */
-	public <B extends Block> RegistryObject<B> createCompatBlock(String modId, String name, Supplier<? extends B> supplier, @Nullable ItemGroup group) {
+	public <B extends Block> RegistryObject<B> createCompatBlock(String name, Supplier<? extends B> supplier, @Nullable ItemGroup group, String ...modIdList) {
+		boolean areModsLoaded = true;
+		if (FMLEnvironment.production)
+			for (String mod : modIdList)
+				areModsLoaded &= ModList.get().isLoaded(mod);
+		ItemGroup determinedGroup = areModsLoaded ? group : null;
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
-		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		this.itemRegister.register(name, () -> new BlockItem(block.get(), new Item.Properties().group(determinedGroup)));
 		return block;
 	}
 
 	/**
 	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
 	 *
-	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
-	 * @param name     - The block's name
-	 * @param supplier - The supplied {@link Block}
-	 * @param burnTime - How many ticks this fuel block should burn for.
-	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
+	 * @param name      - The block's name
+	 * @param supplier  - The supplied {@link Block}
+	 * @param burnTime  - How many ticks this fuel block should burn for
+	 * @param group     - The {@link ItemGroup} for the {@link BlockItem}
+	 * @param modIdList - The mod ids of the mods this block is compatible for
 	 * @return A {@link RegistryObject} containing the created {@link Block}
 	 */
-	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String modId, String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group) {
+	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group, String ...modIdList) {
+		boolean areModsLoaded = true;
+		if (FMLEnvironment.production)
+			for (String mod : modIdList)
+				areModsLoaded &= ModList.get().isLoaded(mod);
+		ItemGroup determinedGroup = areModsLoaded ? group : null;
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
-		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		this.itemRegister.register(name, () -> new FuelBlockItem(block.get(), burnTime, new Item.Properties().group(determinedGroup)));
 		return block;
 	}
 
 	/**
 	 * Creates and registers a {@link AbnormalsChestBlock} and a {@link AbnormalsTrappedChestBlock} with their {@link FuelBlockItem}s.
 	 *
-	 * @param compatModId - The mod id these blocks are compatible for, set to "indev" for dev tests
 	 * @param name        - The name for the chest blocks
 	 * @param color       - The {@link MaterialColor} for the chest blocks
+	 * @param modIdList   - The mod ids of the mods this block is compatible for
 	 * @return A {@link Pair} containing {@link RegistryObject}s of the {@link AbnormalsChestBlock} and the {@link AbnormalsTrappedChestBlock}
 	 */
-	public Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> createCompatChestBlocks(String compatModId, String name, MaterialColor color) {
-		boolean isModLoaded = ModList.get().isLoaded(compatModId) || compatModId == "indev";
-		ItemGroup chestGroup = isModLoaded ? ItemGroup.DECORATIONS : null;
-		ItemGroup trappedChestGroup = isModLoaded ? ItemGroup.REDSTONE : null;
+	public Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> createCompatChestBlocks(String name, MaterialColor color, String ...modIdList) {
+		boolean areModsLoaded = true;
+		if (FMLEnvironment.production)
+			for (String mod : modIdList)
+				areModsLoaded &= ModList.get().isLoaded(mod);
+		ItemGroup chestGroup = areModsLoaded ? ItemGroup.DECORATIONS : null;
+		ItemGroup trappedChestGroup = areModsLoaded ? ItemGroup.REDSTONE : null;
 		String modId = this.parent.getModId();
 		String chestName = name + "_chest";
 		String trappedChestName = name + "_trapped_chest";

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
@@ -226,7 +226,6 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	 * Creates and registers a compat {@link Block}
 	 *
 	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
-	 * @param modId2   - The mod id of the second mod this block is compatible for, set to "indev" for dev tests (optional)
 	 * @param name     - The block's name
 	 * @param supplier - The supplied {@link Block}
 	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
@@ -238,6 +237,16 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		return block;
 	}
 	
+	/**
+	 * Creates and registers a compat {@link Block}
+	 *
+	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param modId2   - The mod id of the second mod this block is compatible for, set to "indev" for dev tests
+	 * @param name     - The block's name
+	 * @param supplier - The supplied {@link Block}
+	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
+	 * @return A {@link RegistryObject} containing the created {@link Block}
+	 */
 	public <B extends Block> RegistryObject<B> createCompatBlock(String modId, String modId2, String name, Supplier<? extends B> supplier, @Nullable ItemGroup group) {
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
 		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;
@@ -249,7 +258,6 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
 	 *
 	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
-	 * @param modId2   - The mod id of the second mod this block is compatible for, set to "indev" for dev tests (optional)
 	 * @param name     - The block's name
 	 * @param supplier - The supplied {@link Block}
 	 * @param burnTime - How many ticks this fuel block should burn for.
@@ -262,6 +270,17 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		return block;
 	}
 	
+	/**
+	 * Creates and registers a compat {@link Block} with a {@link FuelBlockItem}.
+	 *
+	 * @param modId    - The mod id of the mod this block is compatible for, set to "indev" for dev tests
+	 * @param modId2   - The mod id of the second mod this block is compatible for, set to "indev" for dev tests
+	 * @param name     - The block's name
+	 * @param supplier - The supplied {@link Block}
+	 * @param burnTime - How many ticks this fuel block should burn for.
+	 * @param group    - The {@link ItemGroup} for the {@link BlockItem}
+	 * @return A {@link RegistryObject} containing the created {@link Block}
+	 */
 	public <B extends Block> RegistryObject<B> createCompatFuelBlock(String modId, String modId2, String name, Supplier<? extends B> supplier, int burnTime, @Nullable ItemGroup group) {
 		RegistryObject<B> block = this.deferredRegister.register(name, supplier);
 		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/BlockSubRegistryHelper.java
@@ -17,19 +17,13 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialColor;
 import net.minecraft.client.renderer.tileentity.ItemStackTileEntityRenderer;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
-import net.minecraft.item.Rarity;
-import net.minecraft.item.TallBlockItem;
-import net.minecraft.item.WallOrFloorItem;
+import net.minecraft.item.*;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -228,7 +222,7 @@ public class BlockSubRegistryHelper extends AbstractSubRegistryHelper<Block> {
 		this.itemRegister.register(name + "_sign", () -> new AbnormalsSignItem(standing.get(), wall.get(), new Item.Properties().maxStackSize(16).group(ItemGroup.DECORATIONS)));
 		return Pair.of(standing, wall);
 	}
-	
+
 	/**
 	 * Creates and registers a compat {@link Block}
 	 *

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -53,6 +53,7 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	 * Creates and registers a compat {@link Item}
 	 *
 	 * @param modId      - The mod id of the mod this item is compatible for, set to "indev" for dev tests
+	 * @param modId2     - The mod id of the second mod this item is compatible for, set to "indev" for dev tests (optional)
 	 * @param name       - The name for the item
 	 * @param properties - The item's properties
 	 * @param group      - The {@link ItemGroup} for the {@link Item}
@@ -60,6 +61,12 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	 */
 	public RegistryObject<Item> createCompatItem(String modId, String name, Item.Properties properties, ItemGroup group) {
 		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		return item;
+	}
+	
+	public RegistryObject<Item> createCompatItem(String modId, String modId2, String name, Item.Properties properties, ItemGroup group) {
+		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;
+		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(determinedGroup)));
 		return item;
 	}
 

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -19,6 +19,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -57,14 +58,19 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	/**
 	 * Creates and registers a compat {@link Item}
 	 *
-	 * @param modId      - The mod id of the mod this item is compatible for, set to "indev" for dev tests
 	 * @param name       - The name for the item
 	 * @param properties - The item's properties
 	 * @param group      - The {@link ItemGroup} for the {@link Item}
+	 * @param modIdList  - The mod ids of the mods this block is compatible for
 	 * @return A {@link RegistryObject} containing the {@link Item}
 	 */
-	public RegistryObject<Item> createCompatItem(String modId, String name, Item.Properties properties, ItemGroup group) {
-		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+	public RegistryObject<Item> createCompatItem(String name, Item.Properties properties, ItemGroup group, String ...modIdList) {
+		boolean areModsLoaded = true;
+		if (FMLEnvironment.production)
+			for (String mod : modIdList)
+				areModsLoaded &= ModList.get().isLoaded(mod);
+		ItemGroup determinedGroup = areModsLoaded ? group : null;
+		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(determinedGroup)));
 		return item;
 	}
 

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -1,11 +1,5 @@
 package com.teamabnormals.abnormals_core.core.util.registry;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.google.common.collect.Lists;
 import com.teamabnormals.abnormals_core.common.items.AbnormalsBoatItem;
 import com.teamabnormals.abnormals_core.common.items.AbnormalsSpawnEggItem;
@@ -27,6 +21,10 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * A basic {@link AbstractSubRegistryHelper} for items. This contains some useful registering methods for items.
@@ -67,26 +65,6 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	 */
 	public RegistryObject<Item> createCompatItem(String modId, String name, Item.Properties properties, ItemGroup group) {
 		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
-		return item;
-	}
-	
-	/**
-	 * Creates and registers a compat {@link Item}
-	 *
-	 * @param modIdList  - The ArrayList of all the mod ids this item is compatible for
-	 * @param isIndev    - Set to true for dev tests
-	 * @param name       - The name for the item
-	 * @param properties - The item's properties
-	 * @param group      - The {@link ItemGroup} for the {@link Item}
-	 * @return A {@link RegistryObject} containing the {@link Item}
-	 */
-	public RegistryObject<Item> createCompatItem(ArrayList<String> modIdList, boolean isIndev, String name, Item.Properties properties, ItemGroup group) {
-		boolean areModsLoaded = true;
-		if (!isIndev)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
-		ItemGroup determinedGroup = areModsLoaded ? group : null;
-		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(determinedGroup)));
 		return item;
 	}
 

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -1,14 +1,25 @@
 package com.teamabnormals.abnormals_core.core.util.registry;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Lists;
 import com.teamabnormals.abnormals_core.common.items.AbnormalsBoatItem;
 import com.teamabnormals.abnormals_core.common.items.AbnormalsSpawnEggItem;
 import com.teamabnormals.abnormals_core.common.items.FuelItem;
 import com.teamabnormals.abnormals_core.core.registry.BoatRegistry;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.color.ItemColors;
 import net.minecraft.entity.EntityType;
-import net.minecraft.item.*;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.TallBlockItem;
+import net.minecraft.item.WallOrFloorItem;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ColorHandlerEvent;
@@ -16,10 +27,6 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * A basic {@link AbstractSubRegistryHelper} for items. This contains some useful registering methods for items.
@@ -66,15 +73,19 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	/**
 	 * Creates and registers a compat {@link Item}
 	 *
-	 * @param modId      - The mod id of the mod this item is compatible for, set to "indev" for dev tests
-	 * @param modId2     - The mod id of the second mod this item is compatible for, set to "indev" for dev tests
+	 * @param modIdList  - The ArrayList of all the mod ids this item is compatible for
+	 * @param isIndev    - Set to true for dev tests
 	 * @param name       - The name for the item
 	 * @param properties - The item's properties
 	 * @param group      - The {@link ItemGroup} for the {@link Item}
 	 * @return A {@link RegistryObject} containing the {@link Item}
 	 */
-	public RegistryObject<Item> createCompatItem(String modId, String modId2, String name, Item.Properties properties, ItemGroup group) {
-		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;
+	public RegistryObject<Item> createCompatItem(ArrayList<String> modIdList, boolean isIndev, String name, Item.Properties properties, ItemGroup group) {
+		boolean areModsLoaded = true;
+		if (!isIndev)
+			for (String mod : modIdList)
+				areModsLoaded &= ModList.get().isLoaded(mod);
+		ItemGroup determinedGroup = areModsLoaded ? group : null;
 		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(determinedGroup)));
 		return item;
 	}

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -53,7 +53,6 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	 * Creates and registers a compat {@link Item}
 	 *
 	 * @param modId      - The mod id of the mod this item is compatible for, set to "indev" for dev tests
-	 * @param modId2     - The mod id of the second mod this item is compatible for, set to "indev" for dev tests (optional)
 	 * @param name       - The name for the item
 	 * @param properties - The item's properties
 	 * @param group      - The {@link ItemGroup} for the {@link Item}
@@ -64,6 +63,16 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 		return item;
 	}
 	
+	/**
+	 * Creates and registers a compat {@link Item}
+	 *
+	 * @param modId      - The mod id of the mod this item is compatible for, set to "indev" for dev tests
+	 * @param modId2     - The mod id of the second mod this item is compatible for, set to "indev" for dev tests
+	 * @param name       - The name for the item
+	 * @param properties - The item's properties
+	 * @param group      - The {@link ItemGroup} for the {@link Item}
+	 * @return A {@link RegistryObject} containing the {@link Item}
+	 */
 	public RegistryObject<Item> createCompatItem(String modId, String modId2, String name, Item.Properties properties, ItemGroup group) {
 		ItemGroup determinedGroup = (ModList.get().isLoaded(modId) || modId == "indev") && (ModList.get().isLoaded(modId2) || modId2 == "indev") ? group : null;
 		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(determinedGroup)));

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -54,6 +54,20 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	public <I extends Item> RegistryObject<I> createItem(String name, Supplier<? extends I> supplier) {
 		return this.deferredRegister.register(name, supplier);
 	}
+	
+	/**
+	 * Creates and registers a compat {@link Item}
+	 *
+	 * @param modId      - The mod id of the mod this item is compatible for, set to "indev" for dev tests
+	 * @param name       - The name for the item
+	 * @param properties - The item's properties
+	 * @param group      - The {@link ItemGroup} for the {@link Item}
+	 * @return A {@link RegistryObject} containing the {@link Item}
+	 */
+	public RegistryObject<Item> createCompatItem(String modId, String name, Item.Properties properties, ItemGroup group) {
+		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(ModList.get().isLoaded(modId) || modId == "indev" ? group : null)));
+		return item;
+	}
 
 	/**
 	 * Creates and registers a compat {@link Item}
@@ -66,9 +80,8 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	 */
 	public RegistryObject<Item> createCompatItem(String name, Item.Properties properties, ItemGroup group, String ...modIdList) {
 		boolean areModsLoaded = true;
-		if (FMLEnvironment.production)
-			for (String mod : modIdList)
-				areModsLoaded &= ModList.get().isLoaded(mod);
+		for (String mod : modIdList)
+			areModsLoaded &= ModList.get().isLoaded(mod);
 		ItemGroup determinedGroup = areModsLoaded ? group : null;
 		RegistryObject<Item> item = this.deferredRegister.register(name, () -> new Item(properties.group(determinedGroup)));
 		return item;

--- a/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/util/registry/ItemSubRegistryHelper.java
@@ -9,17 +9,12 @@ import com.teamabnormals.abnormals_core.core.registry.BoatRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.color.ItemColors;
 import net.minecraft.entity.EntityType;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
-import net.minecraft.item.TallBlockItem;
-import net.minecraft.item.WallOrFloorItem;
+import net.minecraft.item.*;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.RegistryObject;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -54,7 +49,7 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	public <I extends Item> RegistryObject<I> createItem(String name, Supplier<? extends I> supplier) {
 		return this.deferredRegister.register(name, supplier);
 	}
-	
+
 	/**
 	 * Creates and registers a compat {@link Item}
 	 *

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -30,7 +30,7 @@ public final class TestBlocks {
 	public static final RegistryObject<Block> TEST_LOADER = HELPER.createBlock("test_loader", () -> new ChunkLoadTestBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<Block> TEST_ROTATION = HELPER.createBlock("test_rotation", () -> new RotatedVoxelShapeTestBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 	public static final Pair<RegistryObject<AbnormalsStandingSignBlock>, RegistryObject<AbnormalsWallSignBlock>> SIGNS = HELPER.createSignBlock("test", MaterialColor.PINK);
-	public static final Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> CHESTS = HELPER.createCompatChestBlocks("test_two", "indev", MaterialColor.PURPLE);
+	public static final Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> CHESTS = HELPER.createCompatChestBlocks("test_two", MaterialColor.PURPLE, "indev");
 
 	public static final RegistryObject<AbnormalsChestBlock> EXAMPLE_CHEST = HELPER.createChestBlock("test", Block.Properties.from(Blocks.DIRT), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<AbnormalsTrappedChestBlock> EXAMPLE_TRAPPED_CHEST = HELPER.createTrappedChestBlock("test", Block.Properties.from(Blocks.CHEST), ItemGroup.DECORATIONS);

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -30,7 +30,7 @@ public final class TestBlocks {
 	public static final RegistryObject<Block> TEST_LOADER = HELPER.createBlock("test_loader", () -> new ChunkLoadTestBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<Block> TEST_ROTATION = HELPER.createBlock("test_rotation", () -> new RotatedVoxelShapeTestBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 	public static final Pair<RegistryObject<AbnormalsStandingSignBlock>, RegistryObject<AbnormalsWallSignBlock>> SIGNS = HELPER.createSignBlock("test", MaterialColor.PINK);
-	public static final Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> CHESTS = HELPER.createCompatChestBlocks("test_two", MaterialColor.PURPLE, "indev");
+	public static final Pair<RegistryObject<AbnormalsChestBlock>, RegistryObject<AbnormalsTrappedChestBlock>> CHESTS = HELPER.createCompatChestBlocks("test_two", "indev", MaterialColor.PURPLE);
 
 	public static final RegistryObject<AbnormalsChestBlock> EXAMPLE_CHEST = HELPER.createChestBlock("test", Block.Properties.from(Blocks.DIRT), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<AbnormalsTrappedChestBlock> EXAMPLE_TRAPPED_CHEST = HELPER.createTrappedChestBlock("test", Block.Properties.from(Blocks.CHEST), ItemGroup.DECORATIONS);


### PR DESCRIPTION
This PR adds overloads of the compat methods to allow for compatibility between two different mods. This is used, for example, in Enhanced Mushrooms for glowshroom beehives or in Cookielicious for sweet berry cookie tile vertical slabs. A common use of these methods is for allowing compatibility between some mod and Quark's vertical slabs and is used often enough that I think it warrants a PR here.