### PR TITLE
[1.16.1] Add support for translucent slabfish

### DIFF
--- a/src/main/java/com/teamabnormals/abnormals_core/client/RewardHandler.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/client/RewardHandler.java
@@ -208,6 +208,7 @@ public final class RewardHandler {
 		}
 
 		public static final class SlabfishData {
+			private final boolean translucent;
 			@SerializedName("type")
 			private final String typeUrl;
 			@SerializedName("sweater")
@@ -219,10 +220,15 @@ public final class RewardHandler {
 			private String sweaterUrlCache;
 			private String backpackUrlCache;
 
-			public SlabfishData(String typeUrl, String sweaterUrl, String backpackUrl) {
+			public SlabfishData(boolean translucent, String typeUrl, String sweaterUrl, String backpackUrl) {
+				this.translucent = translucent;
 				this.typeUrl = typeUrl;
 				this.sweaterUrl = sweaterUrl;
 				this.backpackUrl = backpackUrl;
+			}
+
+			public boolean isTranslucent() {
+				return this.translucent;
 			}
 
 			public String getTypeUrl() {

--- a/src/main/java/com/teamabnormals/abnormals_core/client/renderer/SlabfishHatLayerRenderer.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/client/renderer/SlabfishHatLayerRenderer.java
@@ -47,7 +47,7 @@ public class SlabfishHatLayerRenderer extends LayerRenderer<AbstractClientPlayer
 		ModelRenderer backpack = this.model.backpack;
 
 		body.copyModelAngles(this.getEntityModel().bipedHead);
-		body.render(stack, buffer.getBuffer(RenderType.getEntityCutout(typeLocation)), packedLight, OverlayTexture.NO_OVERLAY);
+		body.render(stack, buffer.getBuffer(slabfish.isTranslucent() ? RenderType.getEntityTranslucent(typeLocation) : RenderType.getEntityCutout(typeLocation)), packedLight, OverlayTexture.NO_OVERLAY);
 
 		if (sweaterLocation != null)
 			body.render(stack, buffer.getBuffer(RenderType.getEntityCutout(sweaterLocation)), packedLight, OverlayTexture.NO_OVERLAY);


### PR DESCRIPTION
Enabled with the `translucent` boolean in the `slabfish` object in the rewards JSON.