### PR TITLE
Improved IAgeableEntity methods so forced aging can be handled from Savage & Ravage

### DIFF
--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -2,14 +2,14 @@ package com.teamabnormals.abnormals_core.core.api;
 
 import net.minecraft.entity.LivingEntity;
 
-/***
- * @author abigailfails
+/**
  * Use to make a living entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning and
  * Savage & Ravage's Growth & Youth Potions.
  * <p>Classes implementing this must extend {@link LivingEntity}.</p>
+ *
+ * @author abigailfails
  */
 public interface IAgeableEntity {
-
     /**
      * If the entity can grow to a higher stage, resets any progress made towards it (e.g. age timer).
      */

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -8,23 +8,23 @@ import net.minecraft.entity.LivingEntity;
  * Savage & Ravage's Growth & Youth Potions.
  * Implemented class must extend LivingEntity
  */
-public interface IAgeableEntity{
+public interface IAgeableEntity {
 
     /**
      * If the entity can grow to a higher stage, resets any progress made towards it (e.g. age timer).
-     * */
+     */
     void resetGrowthProgress();
 
     /**
-    * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
-    * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
-    */
+     * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
+     * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
+     */
     boolean canAge(boolean isGrowingUp);
 
     /**
      * Attempts to change the entity's growth stage depending on isGrowingUp.
      * @param isGrowingUp true attempts to grow to a higher stage, false attempts to grow to a lower one.
      * @return the entity it ages into - if growing is implemented such that this doesn't change, it returns itself
-     * */
+     */
     LivingEntity attemptAging(boolean isGrowingUp);
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -14,11 +14,11 @@ public interface IAgeableEntity {
      * */
     void resetGrowthProgress();
 
-    /**
-     * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
-     * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
-     * */
-    boolean canAge(boolean isGrowingUp);
+/**
+ * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
+ * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
+ */
+ boolean canAge(boolean isGrowingUp);
 
     /**
      * Attempts to change the entity's growth stage depending on isGrowingUp.

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -1,29 +1,30 @@
 package com.teamabnormals.abnormals_core.core.api;
 
-import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 
 /***
  * @author abigailfails
- * Use to make an entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning and
+ * Use to make a living entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning and
  * Savage & Ravage's Growth & Youth Potions.
+ * Implemented class must extend LivingEntity
  */
-public interface IAgeableEntity {
+public interface IAgeableEntity{
 
     /**
      * If the entity can grow to a higher stage, resets any progress made towards it (e.g. age timer).
      * */
     void resetGrowthProgress();
 
-/**
- * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
- * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
- */
- boolean canAge(boolean isGrowingUp);
+    /**
+    * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
+    * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
+    */
+    boolean canAge(boolean isGrowingUp);
 
     /**
      * Attempts to change the entity's growth stage depending on isGrowingUp.
      * @param isGrowingUp true attempts to grow to a higher stage, false attempts to grow to a lower one.
      * @return the entity it ages into - if growing is implemented such that this doesn't change, it returns itself
      * */
-    Entity attemptAging(boolean isGrowingUp);
+    LivingEntity attemptAging(boolean isGrowingUp);
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -1,5 +1,7 @@
 package com.teamabnormals.abnormals_core.core.api;
 
+import net.minecraft.entity.Entity;
+
 /***
  * @author abigailfails
  * Use to make an entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning and
@@ -21,6 +23,7 @@ public interface IAgeableEntity {
     /**
      * Attempts to change the entity's growth stage depending on isGrowingUp.
      * @param isGrowingUp true attempts to grow to a higher stage, false attempts to grow to a lower one.
+     * @return the entity it ages into - if growing is implemented such that this doesn't change, it returns itself
      * */
-    void attemptAging(boolean isGrowingUp);
+    Entity attemptAging(boolean isGrowingUp);
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -1,15 +1,26 @@
 package com.teamabnormals.abnormals_core.core.api;
 
 /***
- * @author tessdotcpp
- * Use to make an entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning.
+ * @author abigailfails
+ * Use to make an entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning and
+ * Savage & Ravage's Growth & Youth Potions.
  */
 public interface IAgeableEntity {
-    /**
-     * Sets the growing age of the entity. With a negative value it's considered a child; use this method to check for
-     * an age of 0 or greater and trigger the necessary changes.
-     */
-    void setGrowingAge(int age);
 
-    int getGrowingAge();
+    /**
+     * If the entity can grow to a higher stage, resets any progress made towards it (e.g. age timer).
+     * */
+    void resetGrowthProgress();
+
+    /**
+     * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
+     * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
+     * */
+    boolean canAge(boolean isGrowingUp);
+
+    /**
+     * Attempts to change the entity's growth stage depending on isGrowingUp.
+     * @param isGrowingUp true attempts to grow to a higher stage, false attempts to grow to a lower one.
+     * */
+    void attemptAging(boolean isGrowingUp);
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -22,7 +22,7 @@ public interface IAgeableEntity {
     boolean canAge(boolean growingUp);
 
     /**
-     * Attempts to change the entity's growth stage depending on isGrowingUp.
+     * Attempts to change the entity's growth stage depending on growingUp.
      * @param growingUp True if this should try to grow the entity, or false to try to regress the entity.
      * @return The entity this ages into - if growing is implemented such that this doesn't change, it returns itself.
      */

--- a/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -6,7 +6,7 @@ import net.minecraft.entity.LivingEntity;
  * @author abigailfails
  * Use to make a living entity that doesn't extend AgeableEntity compatible with Quark's potato poisoning and
  * Savage & Ravage's Growth & Youth Potions.
- * Implemented class must extend LivingEntity
+ * <p>Classes implementing this must extend {@link LivingEntity}.</p>
  */
 public interface IAgeableEntity {
 
@@ -16,15 +16,15 @@ public interface IAgeableEntity {
     void resetGrowthProgress();
 
     /**
-     * @param isGrowingUp true checks for a higher growth stage, false checks for a lower one.
-     * @return whether the entity has another stage it can grow or regress to depending on isGrowingUp.
+     * @param growingUp True if this should check for a higher growth stage or false for a lower one.
+     * @return If the entity can grow or regress into another stage depending on growingUp.
      */
-    boolean canAge(boolean isGrowingUp);
+    boolean canAge(boolean growingUp);
 
     /**
      * Attempts to change the entity's growth stage depending on isGrowingUp.
-     * @param isGrowingUp true attempts to grow to a higher stage, false attempts to grow to a lower one.
-     * @return the entity it ages into - if growing is implemented such that this doesn't change, it returns itself
+     * @param growingUp True if this should try to grow the entity, or false to try to regress the entity.
+     * @return The entity this ages into - if growing is implemented such that this doesn't change, it returns itself.
      */
-    LivingEntity attemptAging(boolean isGrowingUp);
+    LivingEntity attemptAging(boolean growingUp);
 }

--- a/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
@@ -12,6 +12,7 @@ import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
+import net.minecraft.util.ActionResultType;
 import net.minecraft.util.SoundEvents;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -35,20 +36,18 @@ public final class CompatEvents {
 			PlayerEntity player = event.getPlayer();
 			CompoundNBT persistentData = target.getPersistentData();
 			if (((IAgeableEntity) target).canAge(true) && !persistentData.getBoolean(POISON_TAG)) {
-				if (!event.getWorld().isRemote) {
-					if (target.world.rand.nextDouble() < ACConfig.ValuesHolder.poisonEffectChance()) {
-						target.playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.25f);
-						persistentData.putBoolean(POISON_TAG, true);
-						if (ACConfig.ValuesHolder.shouldPoisonEntity()) {
-							((LivingEntity) target).addPotionEffect(new EffectInstance(Effects.POISON, 200));
-						}
-					} else {
-						target.playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.5f + target.world.rand.nextFloat() / 2);
+				if (target.world.rand.nextDouble() < ACConfig.ValuesHolder.poisonEffectChance()) {
+					target.playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.25f);
+					persistentData.putBoolean(POISON_TAG, true);
+					if (ACConfig.ValuesHolder.shouldPoisonEntity()) {
+						((LivingEntity) target).addPotionEffect(new EffectInstance(Effects.POISON, 200));
 					}
 				} else {
-					player.swingArm(event.getHand());
+					target.playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.5f + target.world.rand.nextFloat() / 2);
 				}
 				if (!player.isCreative()) stack.shrink(1);
+				event.setCancellationResult(ActionResultType.func_233537_a_(event.getWorld().isRemote()));
+				event.setCanceled(true);
 			}
 		}
 	}

--- a/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
@@ -21,8 +21,9 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 
 /**
- * @author abigailfails
  * Events for mod compatibility.
+ *
+ * @author abigailfails
  */
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID)
 public final class CompatEvents {

--- a/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/teamabnormals/abnormals_core/core/events/CompatEvents.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 
 /**
- * @author tessdotcpp
+ * @author abigailfails
  * Events for mod compatibility.
  */
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID)
@@ -33,12 +33,12 @@ public final class CompatEvents {
 		ItemStack stack = event.getItemStack();
 		if (target instanceof IAgeableEntity && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
 			PlayerEntity player = event.getPlayer();
-			CompoundNBT persistantData = target.getPersistentData();
-			if (((IAgeableEntity) target).getGrowingAge() < 0 && !persistantData.getBoolean(POISON_TAG)) {
+			CompoundNBT persistentData = target.getPersistentData();
+			if (((IAgeableEntity) target).canAge(true) && !persistentData.getBoolean(POISON_TAG)) {
 				if (!event.getWorld().isRemote) {
 					if (target.world.rand.nextDouble() < ACConfig.ValuesHolder.poisonEffectChance()) {
 						target.playSound(SoundEvents.ENTITY_GENERIC_EAT, 0.5f, 0.25f);
-						persistantData.putBoolean(POISON_TAG, true);
+						persistentData.putBoolean(POISON_TAG, true);
 						if (ACConfig.ValuesHolder.shouldPoisonEntity()) {
 							((LivingEntity) target).addPotionEffect(new EffectInstance(Effects.POISON, 200));
 						}
@@ -57,7 +57,7 @@ public final class CompatEvents {
 	public static void onUpdateEntity(LivingEvent.LivingUpdateEvent event) {
 		Entity entity = event.getEntity();
 		if (entity instanceof IAgeableEntity && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
-			if (entity.getPersistentData().getBoolean(POISON_TAG)) ((IAgeableEntity) entity).setGrowingAge(-24000);
+			if (entity.getPersistentData().getBoolean(POISON_TAG)) ((IAgeableEntity) entity).resetGrowthProgress();
 		}
 	}
 }


### PR DESCRIPTION
As I mentioned in the Endergetic PR, `IAgeableEntity` only has age value setting and getting methods which are honestly too specific and limit how growth can be implemented. It also wasn't able to cover the use case of Savage & Ravage's forced growth potions, which this PR allows. However, this will break mods that don't update/older versions being used with the new AC version so I really wouldn't like to have to do it again - if you can think of any use cases that aren't covered by the new methods, feel free to mention it. The same applies to javadoc comments, I found it weirdly hard to write those and I don't know if they're clear enough.