### PR TITLE
[1.16.4] Add villager levels as ints in TradeUtil

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/TradeUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/TradeUtil.java
@@ -11,6 +11,12 @@ import net.minecraftforge.event.village.WandererTradesEvent;
 import net.minecraftforge.fml.ModList;
 
 public final class TradeUtil {
+	public static final int NOVICE = 1;
+	public static final int APPRENTICE = 2;
+	public static final int JOURNEYMAN = 3;
+	public static final int EXPERT = 4;
+	public static final int MASTER = 5;
+	
 	public static class AbnormalsTrade extends BasicTrade {
 		public AbnormalsTrade(ItemStack input, ItemStack input2, ItemStack output, int maxTrades, int xp, float priceMult) {
 			super(input, input2, output, maxTrades, xp, priceMult);


### PR DESCRIPTION
This PR adds 5 `int`s to the beginning of `TradeUtil` allowing one to use the villager level names instead of having to memorize the corresponding integers. This list shouldn't have to be maintained often as it seems unlikely Mojang will be changing anything related to villagers anytime soon.

If this would rather be moved to an internal class or somewhere else, let me know.