### PR TITLE
Another oversight in IAgeableEntity

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -10,6 +10,12 @@ import net.minecraft.entity.LivingEntity;
  * @author abigailfails
  */
 public interface IAgeableEntity {
+    
+    /**
+     * @return If the entity will make any natural progress towards the next stage. If false, potato poisoning will not work.
+     */
+    boolean hasGrowthProgress();
+    
     /**
      * If the entity can grow to a higher stage, resets any progress made towards it (e.g. age timer).
      */

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/IAgeableEntity.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/IAgeableEntity.java
@@ -10,7 +10,6 @@ import net.minecraft.entity.LivingEntity;
  * @author abigailfails
  */
 public interface IAgeableEntity {
-    
     /**
      * @return If the entity will make any natural progress towards the next stage. If false, potato poisoning will not work.
      */

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
@@ -33,7 +33,7 @@ public final class CompatEvents {
 	public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
 		Entity target = event.getTarget();
 		ItemStack stack = event.getItemStack();
-		if (target instanceof IAgeableEntity && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
+		if (target instanceof IAgeableEntity && ((IAgeableEntity)target).hasGrowthProgress() && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
 			PlayerEntity player = event.getPlayer();
 			CompoundNBT persistentData = target.getPersistentData();
 			if (((IAgeableEntity) target).canAge(true) && !persistentData.getBoolean(POISON_TAG)) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
@@ -33,7 +33,7 @@ public final class CompatEvents {
 	public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
 		Entity target = event.getTarget();
 		ItemStack stack = event.getItemStack();
-		if (target instanceof IAgeableEntity && ((IAgeableEntity)target).hasGrowthProgress() && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
+		if (target instanceof IAgeableEntity && ((IAgeableEntity) target).hasGrowthProgress() && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
 			PlayerEntity player = event.getPlayer();
 			CompoundNBT persistentData = target.getPersistentData();
 			if (((IAgeableEntity) target).canAge(true) && !persistentData.getBoolean(POISON_TAG)) {


### PR DESCRIPTION
I was thinking about using this with jellyfish (because bagel suggested them working with growth and youth potions ages ago) and realised that there should be a way to have higher growth stages that work with the potion but not naturally, and therefore potato poisoning shouldn't apply to them. 