### PR TITLE
Added method that adds item to jigsaw pool

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
@@ -156,7 +156,7 @@ public final class BlockUtil {
 	 * @return A {@link List} of entities at the at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<Entity> entityType) {
+	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends Entity> entityType) {
 		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)));
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
@@ -143,7 +143,7 @@ public final class BlockUtil {
 	 * @return The {@link BlockState} at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static BlockState stateAtOffsetPos(IBlockSource source) {
+	public static BlockState getStateAtOffsetPos(IBlockSource source) {
 		return source.getWorld().getBlockState(offsetPos(source));
 	}
 
@@ -156,7 +156,7 @@ public final class BlockUtil {
 	 * @return A {@link List} of entities at the at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static List<Entity> entitiesAtOffsetPos(IBlockSource source, Class<Entity> entityType) {
+	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<Entity> entityType) {
 		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)));
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
@@ -168,7 +168,7 @@ public final class BlockUtil {
 	 * @param entityType The class extending {@link Entity} to search for. Set to {@code Entity.class} to get all entities, regardless of type.
 	 * @param predicate The predicate with type parameter extending {@link Entity} to check against.
 	 *
-	 * @return A {@link List} of entities at the at the offset position.
+	 * @return A {@link List} of entities at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
 	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends Entity> entityType, Predicate<? super Entity> predicate) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
@@ -149,29 +149,29 @@ public final class BlockUtil {
 	}
 
 	/**
-	 * Gets a {@link List} of entities at the position returned by {@link #offsetPos(IBlockSource source)}.
+	 * Gets a {@link List} of type {@link T} at the position returned by {@link #offsetPos(IBlockSource source)}.
 	 *
 	 * @param source The {@link IBlockSource} to get the position from.
-	 * @param entityType The class extending {@link Entity} to search for. Set to {@code Entity.class} to get all entities, regardless of type.
+	 * @param entityType The class extending {@link T} to search for. Set to {@code Entity.class} to get all entities, regardless of type.
 	 *
 	 * @return A {@link List} of entities at the at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends Entity> entityType) {
+	public static<T extends Entity> List<T> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends T> entityType) {
 		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)));
 	}
 
 	/**
-	 * Gets a {@link List} of entities that match a {@link Predicate} at the position returned by {@link #offsetPos(IBlockSource source)}.
+	 * Gets a {@link List} of type {@link T} that match a {@link Predicate} at the position returned by {@link #offsetPos(IBlockSource source)}.
 	 *
 	 * @param source The {@link IBlockSource} to get the position from.
-	 * @param entityType The class extending {@link Entity} to search for. Set to {@code Entity.class} to get all entities, regardless of type.
-	 * @param predicate The predicate with type parameter extending {@link Entity} to check against.
+	 * @param entityType The class extending {@link T} to search for. Set to {@code Entity.class} to get all entities, regardless of type.
+	 * @param predicate The predicate that takes a superclass of {@link T} as an argument to check against.
 	 *
-	 * @return A {@link List} of entities at the offset position.
+	 * @return A {@link List} of entities at the at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends Entity> entityType, Predicate<? super Entity> predicate) {
+	public static<T extends Entity> List<T> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends T> entityType, Predicate<? super T> predicate) {
 		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)), predicate);
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
@@ -143,7 +143,7 @@ public final class BlockUtil {
 	 * @return The {@link BlockState} at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static BlockState getStateAtOffsetPos(IBlockSource source) {
+	public static BlockState stateAtOffsetPos(IBlockSource source) {
 		return source.getWorld().getBlockState(offsetPos(source));
 	}
 
@@ -156,7 +156,7 @@ public final class BlockUtil {
 	 * @return A {@link List} of entities at the at the offset position.
 	 * @see #offsetPos(IBlockSource source)
 	 */
-	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<Entity> entityType) {
+	public static List<Entity> entitiesAtOffsetPos(IBlockSource source, Class<Entity> entityType) {
 		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)));
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/BlockUtil.java
@@ -2,6 +2,7 @@ package com.minecraftabnormals.abnormals_core.core.util;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import net.minecraft.block.Block;
@@ -158,5 +159,19 @@ public final class BlockUtil {
 	 */
 	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends Entity> entityType) {
 		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)));
+	}
+
+	/**
+	 * Gets a {@link List} of entities that match a {@link Predicate} at the position returned by {@link #offsetPos(IBlockSource source)}.
+	 *
+	 * @param source The {@link IBlockSource} to get the position from.
+	 * @param entityType The class extending {@link Entity} to search for. Set to {@code Entity.class} to get all entities, regardless of type.
+	 * @param predicate The predicate with type parameter extending {@link Entity} to check against.
+	 *
+	 * @return A {@link List} of entities at the at the offset position.
+	 * @see #offsetPos(IBlockSource source)
+	 */
+	public static List<Entity> getEntitiesAtOffsetPos(IBlockSource source, Class<? extends Entity> entityType, Predicate<? super Entity> predicate) {
+		return source.getWorld().getEntitiesWithinAABB(entityType, new AxisAlignedBB(offsetPos(source)), predicate);
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -110,7 +110,9 @@ public final class DataUtil {
 	 */
 	public static void registerAlternativeDispenseBehavior(Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior newBehavior) {
 		IDispenseItemBehavior oldBehavior = DispenserBlock.DISPENSE_BEHAVIOR_REGISTRY.get(item);
-		DispenserBlock.registerDispenseBehavior(item, (source, stack) -> condition.test(source, stack) ? newBehavior.dispense(source, stack) : oldBehavior.dispense(source, stack));
+		DispenserBlock.registerDispenseBehavior(item, (source, stack) -> {
+			return condition.test(source, stack) ? newBehavior.dispense(source, stack) : oldBehavior.dispense(source, stack);
+		});
 	}
 
 	/**

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -123,7 +123,6 @@ public final class DataUtil {
 	 * @param weight The probability weight of {@code newPiece}.
 	 *
 	 * @author abigailfails
-	 *
 	 */
 	public static void addToJigsawPattern(ResourceLocation toAdd, JigsawPiece newPiece, int weight) {
 		JigsawPattern oldPool = WorldGenRegistries.JIGSAW_POOL.getOrDefault(toAdd);

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -129,8 +129,9 @@ public final class DataUtil {
 		JigsawPattern oldPool = WorldGenRegistries.JIGSAW_POOL.getOrDefault(toAdd);
 		if (oldPool != null) {
 			oldPool.rawTemplates.add(Pair.of(newPiece, weight));
+			List<JigsawPiece> jigsawPieces = oldPool.jigsawPieces;
 			for (int i = 0; i < weight; i++) {
-				oldPool.jigsawPieces.add(newPiece);
+				jigsawPieces.add(newPiece);
 			}
 		}
 	}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -123,12 +123,13 @@ public final class DataUtil {
 	 * @param weight The probability weight of {@code newPiece}.
 	 *
 	 * @author abigailfails
-	 * */
+	 *
+	 */
 	public static void addToJigsawPattern(ResourceLocation toAdd, JigsawPiece newPiece, int weight) {
 		JigsawPattern oldPool = WorldGenRegistries.JIGSAW_POOL.getOrDefault(toAdd);
 		if (oldPool != null) {
 			oldPool.rawTemplates.add(Pair.of(newPiece, weight));
-			for (int i=0; i<weight; i++) {
+			for (int i = 0; i < weight; i++) {
 				oldPool.jigsawPieces.add(newPiece);
 			}
 		}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -124,9 +124,9 @@ public final class DataUtil {
 	 * */
 	public static void addToJigsawPattern(ResourceLocation toAdd, JigsawPiece newPiece, int weight) {
 		JigsawPattern oldPool = WorldGenRegistries.JIGSAW_POOL.getOrDefault(toAdd);
-		if(oldPool != null) {
+		if (oldPool != null) {
 			oldPool.rawTemplates.add(Pair.of(newPiece, weight));
-			for(int i=0; i<weight; i++) {
+			for (int i=0; i<weight; i++) {
 				oldPool.jigsawPieces.add(newPiece);
 			}
 		}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.abnormals_core.core.util;
 
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ComposterBlock;
@@ -19,6 +20,9 @@ import net.minecraft.potion.PotionBrewing;
 import net.minecraft.util.IItemProvider;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.WorldGenRegistries;
+import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
+import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
@@ -106,8 +110,25 @@ public final class DataUtil {
 	 */
 	public static void registerAlternativeDispenseBehavior(Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior newBehavior) {
 		IDispenseItemBehavior oldBehavior = DispenserBlock.DISPENSE_BEHAVIOR_REGISTRY.get(item);
-		DispenserBlock.registerDispenseBehavior(item, (source, stack) -> {
-			return condition.test(source, stack) ? newBehavior.dispense(source, stack) : oldBehavior.dispense(source, stack);
-		});
+		DispenserBlock.registerDispenseBehavior(item, (source, stack) -> condition.test(source, stack) ? newBehavior.dispense(source, stack) : oldBehavior.dispense(source, stack));
+	}
+
+	/**
+	 * Adds a new {@link JigsawPiece} to a pre-existing {@link JigsawPattern}.
+	 *
+	 * @param toAdd The {@link ResourceLocation} of the pattern to insert the new piece into.
+	 * @param newPiece The {@link JigsawPiece} to insert into {@code toAdd}.
+	 * @param weight The probability weight of {@code newPiece}.
+	 *
+	 * @author abigailfails
+	 * */
+	public static void addToJigsawPattern(ResourceLocation toAdd, JigsawPiece newPiece, int weight) {
+		JigsawPattern oldPool = WorldGenRegistries.JIGSAW_POOL.getOrDefault(toAdd);
+		if(oldPool != null) {
+			oldPool.rawTemplates.add(Pair.of(newPiece, weight));
+			for(int i=0; i<weight; i++) {
+				oldPool.jigsawPieces.add(newPiece);
+			}
+		}
 	}
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -19,3 +19,5 @@ public net.minecraft.advancements.AdvancementRewards field_192117_d # recipes
 public net.minecraft.advancements.AdvancementRewards field_193129_e # function
 public net.minecraft.world.gen.layer.HillsLayer field_242940_c # field_242940_c
 public net.minecraft.block.DispenserBlock field_149943_a # DISPENSE_BEHAVIOR_REGISTRY
+public net.minecraft.world.gen.feature.jigsaw.JigsawPattern field_214952_d # rawTemplates
+public net.minecraft.world.gen.feature.jigsaw.JigsawPattern field_214953_e # jigsawPieces


### PR DESCRIPTION
I'm planning to use this for a small thing in S&R but I think it would be good for AC as it has other applications - for example, Buzzier Bees also adds to village housing pools using a more situational method.

This PR also renames `getStateAtOffsetPos` to `stateAtOffsetPos` and `getEntitiesAtOffsetPos` to `entitiesAtOffsetPos.` I felt that the 'get' was a bit redundant.