### PR TITLE
Add support for Quark's wooden posts

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
@@ -2,9 +2,7 @@ package com.minecraftabnormals.abnormals_core.common.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorldReader;
 
 public class BookshelfBlock extends Block {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
@@ -2,7 +2,9 @@ package com.minecraftabnormals.abnormals_core.common.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorldReader;
 
 public class BookshelfBlock extends Block {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -15,7 +15,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 
 public class WoodPostBlock extends Block implements IWaterLoggable {
-	private static final VoxelShape SHAPE = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
+	private static final VoxelShape SHAPE = Block.makeCuboidShape(6.0F, 0.0F, 6.0F, 10.0F, 16.0F, 10.0F);
 	private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 	
 	public WoodPostBlock(Properties properties) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -1,0 +1,49 @@
+package com.minecraftabnormals.abnormals_core.common.blocks.wood;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.IWaterLoggable;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.world.IBlockReader;
+
+public class WoodPostBlock extends Block implements IWaterLoggable {
+	private static final VoxelShape SHAPE = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
+	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	
+	public WoodPostBlock(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
+		return SHAPE;
+	}
+
+	@Override
+	public boolean propagatesSkylightDown(BlockState state, IBlockReader reader, BlockPos pos) {
+		return !state.get(WATERLOGGED);
+	}
+
+	@Override
+	public FluidState getFluidState(BlockState state) {
+		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+	}
+	
+	@Override
+	public BlockState getStateForPlacement(BlockItemUseContext context) {
+		return this.getDefaultState().with(WATERLOGGED, context.getWorld().getFluidState(context.getPos()).getFluid() == Fluids.WATER);
+	}
+
+	@Override
+	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		builder.add(WATERLOGGED);
+	}
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -16,7 +16,7 @@ import net.minecraft.world.IBlockReader;
 
 public class WoodPostBlock extends Block implements IWaterLoggable {
 	private static final VoxelShape SHAPE = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
-	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 	
 	public WoodPostBlock(Properties properties) {
 		super(properties);

--- a/src/main/resources/assets/abnormals_core/models/block/post.json
+++ b/src/main/resources/assets/abnormals_core/models/block/post.json
@@ -1,0 +1,19 @@
+{
+    "parent": "minecraft:block/block",
+    "textures": {
+        "particle": "#side"
+    },
+    "elements": [
+        {   "from": [ 6, 0, 6 ],
+            "to": [ 10, 16, 10 ],
+            "faces": {
+                "down":  { "uv": [ 6, 6, 10, 10 ], "texture": "#top", "cullface": "down" },
+                "up":    { "uv": [ 6, 6, 10, 10 ], "texture": "#top", "cullface": "up" },
+                "north": { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
+                "south": { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
+                "west":  { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
+                "east":  { "uv": [ 6, 0, 10, 16 ], "texture": "#side" }
+            }
+        }
+    ]
+}

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -7,6 +7,7 @@ import com.minecraftabnormals.abnormals_core.common.blocks.chest.AbnormalsTrappe
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsStandingSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsWallSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.AbnormalsLogBlock;
+import com.minecraftabnormals.abnormals_core.common.blocks.wood.WoodPostBlock;
 import com.minecraftabnormals.abnormals_core.core.annotations.Test;
 import com.minecraftabnormals.abnormals_core.core.util.registry.BlockSubRegistryHelper;
 import common.blocks.ChunkLoadTestBlock;
@@ -37,4 +38,5 @@ public final class TestBlocks {
 
 	public static final RegistryObject<Block> LOG_BLOCK = HELPER.createBlock("log_block", () -> new AbnormalsLogBlock(() -> Blocks.STRIPPED_ACACIA_LOG, AbstractBlock.Properties.create(Material.WOOD, MaterialColor.ADOBE)), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<Block> BEEHIVE = HELPER.createBlock("example_beehive", () -> new AbnormalsBeehiveBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.DECORATIONS);
+	public static final RegistryObject<Block> POST = HELPER.createBlock("post", () -> new WoodPostBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 }


### PR DESCRIPTION
Follow up to #49 that adds a new class `WoodPostBlock` and a new model file to accommodate the new wooden posts in Quark in addition to removing two unused imports in the `BookshelfBlock` class.