### PR TITLE
Added conditions to advancement modifiers

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/advancement/modification/AdvancementModificationManager.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/advancement/modification/AdvancementModificationManager.java
@@ -94,19 +94,17 @@ public final class AdvancementModificationManager extends JsonReloadListener {
 		modifiers.forEach(element -> {
 			JsonObject entry = element.getAsJsonObject();
 			String type = JSONUtils.getString(entry, "type");
-			AdvancementModifier<?> modifier = AdvancementModifiers.getModifier(type);
-			if (modifier == null) {
-				throw new JsonParseException("Unknown Advancement Modifier type: " + type);
-			}
-			JsonElement config = entry.get("config");
-			if (config == null) {
-				throw new JsonParseException("Missing 'config' element!");
-			}
 			if (!JSONUtils.hasField(entry, "conditions") || CraftingHelper.processConditions(JSONUtils.getJsonArray(entry, "conditions"))) {
-			                advancementModifiers.add(modifier.deserialize(config, conditionArrayParser));
-			} else {
-			      AbnormalsCore.LOGGER.info("Skipped advancement modifier \"" + type + "\" for advancement \"" + advancement + "\" as its conditions were not met");
-			}
+				AdvancementModifier<?> modifier = AdvancementModifiers.getModifier(type);
+				if (modifier == null) {
+					throw new JsonParseException("Unknown Advancement Modifier type: " + type);
+				}
+				JsonElement config = entry.get("config");
+				if (config == null) {
+					throw new JsonParseException("Missing 'config' element!");
+				}
+				advancementModifiers.add(modifier.deserialize(config, conditionArrayParser));
+			} else AbnormalsCore.LOGGER.info("Skipped advancement modifier \"" + type + "\" for advancement \"" + advancement + "\" as its conditions were not met");
 		});
 		return new TargetedAdvancementModifier(advancement, advancementModifiers);
 	}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/advancement/modification/AdvancementModificationManager.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/advancement/modification/AdvancementModificationManager.java
@@ -17,6 +17,7 @@ import net.minecraft.resources.IResourceManager;
 import net.minecraft.resources.SimpleReloadableResourceManager;
 import net.minecraft.util.JSONUtils;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -101,7 +102,14 @@ public final class AdvancementModificationManager extends JsonReloadListener {
 			if (config == null) {
 				throw new JsonParseException("Missing 'config' element!");
 			}
-			advancementModifiers.add(modifier.deserialize(config, conditionArrayParser));
+			boolean conditionsMet = true;
+			if (JSONUtils.hasField(entry, "conditions")) {
+				if (!CraftingHelper.processConditions(JSONUtils.getJsonArray(entry, "conditions"))) {
+					AbnormalsCore.LOGGER.info("Skipped advancement modifier \"" + type + "\" for advancement \"" + advancement + "\" as its conditions were not met");
+					conditionsMet = false;
+				}
+			}
+			if (conditionsMet) advancementModifiers.add(modifier.deserialize(config, conditionArrayParser));
 		});
 		return new TargetedAdvancementModifier(advancement, advancementModifiers);
 	}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/advancement/modification/AdvancementModificationManager.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/advancement/modification/AdvancementModificationManager.java
@@ -102,14 +102,11 @@ public final class AdvancementModificationManager extends JsonReloadListener {
 			if (config == null) {
 				throw new JsonParseException("Missing 'config' element!");
 			}
-			boolean conditionsMet = true;
-			if (JSONUtils.hasField(entry, "conditions")) {
-				if (!CraftingHelper.processConditions(JSONUtils.getJsonArray(entry, "conditions"))) {
-					AbnormalsCore.LOGGER.info("Skipped advancement modifier \"" + type + "\" for advancement \"" + advancement + "\" as its conditions were not met");
-					conditionsMet = false;
-				}
+			if (!JSONUtils.hasField(entry, "conditions") || CraftingHelper.processConditions(JSONUtils.getJsonArray(entry, "conditions"))) {
+			                advancementModifiers.add(modifier.deserialize(config, conditionArrayParser));
+			} else {
+			      AbnormalsCore.LOGGER.info("Skipped advancement modifier \"" + type + "\" for advancement \"" + advancement + "\" as its conditions were not met");
 			}
-			if (conditionsMet) advancementModifiers.add(modifier.deserialize(config, conditionArrayParser));
 		});
 		return new TargetedAdvancementModifier(advancement, advancementModifiers);
 	}

--- a/src/test/resources/data/ac_test/modifiers/advancements/balanced_diet.json
+++ b/src/test/resources/data/ac_test/modifiers/advancements/balanced_diet.json
@@ -7,6 +7,11 @@
 	},
 	{
 	  "type": "rewards",
+	  "conditions": [
+		  {
+			  "type": "forge:true"
+		  }
+	  ],
 	  "config": {
 		"mode": "modify",
 		"experience": 100000,
@@ -17,6 +22,11 @@
 	},
 	{
 	  "type": "display",
+	  "conditions": [
+		  {
+			  "type": "forge:true"
+		  }
+	  ],
 	  "config": {
 		"mode": "modify",
 		"title": {
@@ -30,6 +40,11 @@
 	},
 	{
 	  "type": "criteria",
+	  "conditions": [
+		  {
+			  "type": "forge:true"
+		  }
+	  ],
 	  "config": {
 		"mode": "modify",
 		"criteria": {

--- a/src/test/resources/data/ac_test/modifiers/advancements/balanced_diet.json
+++ b/src/test/resources/data/ac_test/modifiers/advancements/balanced_diet.json
@@ -7,11 +7,6 @@
 	},
 	{
 	  "type": "rewards",
-	  "conditions": [
-		  {
-			  "type": "forge:true"
-		  }
-	  ],
 	  "config": {
 		"mode": "modify",
 		"experience": 100000,
@@ -22,11 +17,6 @@
 	},
 	{
 	  "type": "display",
-	  "conditions": [
-		  {
-			  "type": "forge:true"
-		  }
-	  ],
 	  "config": {
 		"mode": "modify",
 		"title": {
@@ -40,11 +30,6 @@
 	},
 	{
 	  "type": "criteria",
-	  "conditions": [
-		  {
-			  "type": "forge:true"
-		  }
-	  ],
 	  "config": {
 		"mode": "modify",
 		"criteria": {


### PR DESCRIPTION
I know you said you didn't feel this was needed, but it ended up being a very simple change. With this PR modifiers can take an optional `conditions` argument, and modifiers whose conditions aren't met won't be deserialised.