### PR TITLE
Updates to Quark wooden post compat

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
@@ -2,9 +2,7 @@ package com.minecraftabnormals.abnormals_core.common.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorldReader;
 
 public class BookshelfBlock extends Block {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
@@ -2,7 +2,9 @@ package com.minecraftabnormals.abnormals_core.common.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorldReader;
 
 public class BookshelfBlock extends Block {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/StrippedWoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/StrippedWoodPostBlock.java
@@ -40,7 +40,7 @@ public class StrippedWoodPostBlock extends Block implements IWaterLoggable {
 		
 		BlockState defaultState = stateContainer.getBaseState().with(WATERLOGGED, false).with(AXIS, Axis.Y);
 		for (BooleanProperty prop : CHAINED)
-			defaultState.with(prop, false);
+			defaultState = defaultState.with(prop, false);
 		this.setDefaultState(defaultState);
 	}
 
@@ -83,7 +83,7 @@ public class StrippedWoodPostBlock extends Block implements IWaterLoggable {
 	}
 	
 	private BlockState getState(World world, BlockPos pos, Axis axis) {
-		BlockState state = getDefaultState().with(WATERLOGGED, world.getFluidState(pos).getFluid() == Fluids.WATER).with(AXIS, axis);
+		BlockState state = this.getDefaultState().with(WATERLOGGED, world.getFluidState(pos).getFluid() == Fluids.WATER).with(AXIS, axis);
 
 		for (Direction d : Direction.values()) {
 			if (d.getAxis() == axis)

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/StrippedWoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/StrippedWoodPostBlock.java
@@ -1,0 +1,95 @@
+package com.minecraftabnormals.abnormals_core.common.blocks.wood;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ChainBlock;
+import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.LanternBlock;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.EnumProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.Direction;
+import net.minecraft.util.Direction.Axis;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
+
+public class StrippedWoodPostBlock extends Block implements IWaterLoggable {
+	private static final VoxelShape SHAPE_X = Block.makeCuboidShape(0F, 6F, 6F, 16F, 10F, 10F);
+	private static final VoxelShape SHAPE_Y = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
+	private static final VoxelShape SHAPE_Z = Block.makeCuboidShape(6F, 6F, 0F, 10F, 10F, 16F);
+	private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	private static final EnumProperty<Axis> AXIS = BlockStateProperties.AXIS;
+	private static final BooleanProperty[] CHAINED = new BooleanProperty[] {
+			BooleanProperty.create("chain_down"),
+			BooleanProperty.create("chain_up"),
+			BooleanProperty.create("chain_north"),
+			BooleanProperty.create("chain_south"),
+			BooleanProperty.create("chain_west"),
+			BooleanProperty.create("chain_east")
+	};
+	
+	public StrippedWoodPostBlock(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
+		switch (state.get(AXIS)) {
+		case X: return SHAPE_X;
+		case Y: return SHAPE_Y;
+		default: return SHAPE_Z;
+		}
+	}
+
+	@Override
+	public boolean propagatesSkylightDown(BlockState state, IBlockReader reader, BlockPos pos) {
+		return !state.get(WATERLOGGED);
+	}
+
+	@Override
+	public FluidState getFluidState(BlockState state) {
+		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+	}
+	
+	@Override
+	public BlockState getStateForPlacement(BlockItemUseContext context) {
+		return getState(context.getWorld(), context.getPos(), context.getFace().getAxis());
+	}
+	
+	@Override
+	public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos, boolean isMoving) {
+		BlockState newState = getState(worldIn, pos, state.get(AXIS));
+		if (!newState.equals(state))
+			worldIn.setBlockState(pos, newState);
+	}
+
+	@Override
+	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		builder.add(WATERLOGGED, AXIS);
+		for (BooleanProperty prop : CHAINED)
+			builder.add(prop);
+	}
+	
+	private BlockState getState(World world, BlockPos pos, Axis axis) {
+		BlockState state = getDefaultState().with(WATERLOGGED, world.getFluidState(pos).getFluid() == Fluids.WATER).with(AXIS, axis);
+
+		for (Direction d : Direction.values()) {
+			if (d.getAxis() == axis)
+				continue;
+
+			BlockState sideState = world.getBlockState(pos.offset(d));
+			if ((sideState.getBlock() instanceof ChainBlock && sideState.get(BlockStateProperties.AXIS) == d.getAxis()) 
+					|| (d == Direction.DOWN && sideState.getBlock() instanceof LanternBlock && sideState.get(LanternBlock.HANGING)))
+				state = state.with(CHAINED[d.ordinal()], true);
+		}
+
+		return state;
+	}
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/StrippedWoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/StrippedWoodPostBlock.java
@@ -37,6 +37,11 @@ public class StrippedWoodPostBlock extends Block implements IWaterLoggable {
 	
 	public StrippedWoodPostBlock(Properties properties) {
 		super(properties);
+		
+		BlockState defaultState = stateContainer.getBaseState().with(WATERLOGGED, false).with(AXIS, Axis.Y);
+		for (BooleanProperty prop : CHAINED)
+			defaultState.with(prop, false);
+		this.setDefaultState(defaultState);
 	}
 
 	@Override

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -1,49 +1,30 @@
 package com.minecraftabnormals.abnormals_core.common.blocks.wood;
 
+import java.util.function.Supplier;
+
+import com.minecraftabnormals.abnormals_core.core.util.BlockUtil;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.IWaterLoggable;
-import net.minecraft.fluid.FluidState;
-import net.minecraft.fluid.Fluids;
-import net.minecraft.item.BlockItemUseContext;
-import net.minecraft.state.BooleanProperty;
-import net.minecraft.state.StateContainer;
-import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.shapes.ISelectionContext;
-import net.minecraft.util.math.shapes.VoxelShape;
-import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ToolType;
 
-public class WoodPostBlock extends Block implements IWaterLoggable {
-	private static final VoxelShape SHAPE = Block.makeCuboidShape(6.0F, 0.0F, 6.0F, 10.0F, 16.0F, 10.0F);
-	private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
-	
-	public WoodPostBlock(Properties properties) {
+public class WoodPostBlock extends StrippedWoodPostBlock {
+	private final Supplier<Block> block;
+
+	public WoodPostBlock(Supplier<Block> suppliedBlock, Properties properties) {
 		super(properties);
-	}
-
-	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
-		return SHAPE;
-	}
-
-	@Override
-	public boolean propagatesSkylightDown(BlockState state, IBlockReader reader, BlockPos pos) {
-		return !state.get(WATERLOGGED);
-	}
-
-	@Override
-	public FluidState getFluidState(BlockState state) {
-		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+		this.block = suppliedBlock;
 	}
 	
 	@Override
-	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		return this.getDefaultState().with(WATERLOGGED, context.getWorld().getFluidState(context.getPos()).getFluid() == Fluids.WATER);
+	public BlockState getToolModifiedState(BlockState state, World world, BlockPos pos, PlayerEntity player, ItemStack stack, ToolType toolType) {
+		if (toolType == ToolType.AXE)
+			return block != null ? BlockUtil.transferAllBlockStates(state, this.block.get().getDefaultState()) : null;
+		return super.getToolModifiedState(state, world, pos, player, stack, toolType);
 	}
 
-	@Override
-	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-		builder.add(WATERLOGGED);
-	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -15,7 +15,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 
 public class WoodPostBlock extends Block implements IWaterLoggable {
-	private static final VoxelShape SHAPE = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
+	private static final VoxelShape SHAPE = Block.makeCuboidShape(6.0F, 0.0F, 6.0F, 10.0F, 16.0F, 10.0F);
 	private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 	
 	public WoodPostBlock(Properties properties) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -1,0 +1,49 @@
+package com.minecraftabnormals.abnormals_core.common.blocks.wood;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.IWaterLoggable;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.world.IBlockReader;
+
+public class WoodPostBlock extends Block implements IWaterLoggable {
+	private static final VoxelShape SHAPE = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
+	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	
+	public WoodPostBlock(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
+		return SHAPE;
+	}
+
+	@Override
+	public boolean propagatesSkylightDown(BlockState state, IBlockReader reader, BlockPos pos) {
+		return !state.get(WATERLOGGED);
+	}
+
+	@Override
+	public FluidState getFluidState(BlockState state) {
+		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+	}
+	
+	@Override
+	public BlockState getStateForPlacement(BlockItemUseContext context) {
+		return this.getDefaultState().with(WATERLOGGED, context.getWorld().getFluidState(context.getPos()).getFluid() == Fluids.WATER);
+	}
+
+	@Override
+	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		builder.add(WATERLOGGED);
+	}
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -1,9 +1,7 @@
 package com.minecraftabnormals.abnormals_core.common.blocks.wood;
 
 import java.util.function.Supplier;
-
 import com.minecraftabnormals.abnormals_core.core.util.BlockUtil;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;

--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/wood/WoodPostBlock.java
@@ -16,7 +16,7 @@ import net.minecraft.world.IBlockReader;
 
 public class WoodPostBlock extends Block implements IWaterLoggable {
 	private static final VoxelShape SHAPE = Block.makeCuboidShape(6F, 0F, 6F, 10F, 16F, 10F);
-	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 	
 	public WoodPostBlock(Properties properties) {
 		super(properties);

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/LanternBlockMixin.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/LanternBlockMixin.java
@@ -1,0 +1,23 @@
+package com.minecraftabnormals.abnormals_core.core.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.minecraftabnormals.abnormals_core.common.blocks.wood.StrippedWoodPostBlock;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.LanternBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorldReader;
+
+@Mixin(LanternBlock.class)
+public class LanternBlockMixin {
+	
+	@Inject(method = "isValidPosition", at = @At("RETURN"), cancellable = true)
+	private void isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos, CallbackInfoReturnable<Boolean> callbackInfoReturnable) {
+		callbackInfoReturnable.setReturnValue(callbackInfoReturnable.getReturnValue() || (state.get(LanternBlock.HANGING) && worldIn.getBlockState(pos.up()).getBlock() instanceof StrippedWoodPostBlock));
+	}
+
+}

--- a/src/main/resources/abnormals_core.mixins.json
+++ b/src/main/resources/abnormals_core.mixins.json
@@ -11,6 +11,7 @@
     "FluidInvokerMixin",
     "HillsLayerMixin",
     "ItemInvokerMixin",
+    "LanternBlockMixin",
     "ServerWorldMixin",
     "SpawnEggItemMixin",
     "TrackedEntityMixin",

--- a/src/main/resources/assets/abnormals_core/models/block/chain_small.json
+++ b/src/main/resources/assets/abnormals_core/models/block/chain_small.json
@@ -1,0 +1,29 @@
+{
+	"parent": "block/block",
+	"textures": {
+		"particle": "block/chain",
+		"all": "block/chain"
+	},
+	"elements": [
+		{
+			"from": [6.5, 0, 8],
+			"to": [9.5, 6, 8],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 10, 3, 16], "texture": "#all"},
+				"south": {"uv": [0, 10, 3, 16], "texture": "#all"}
+			}
+		},
+		{
+			"from": [8, 0, 6.5],
+			"to": [8, 6, 9.5],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"east": {"uv": [3, 10, 6, 16], "texture": "#all"},
+				"west": {"uv": [3, 10, 6, 16], "texture": "#all"}
+			}
+		}
+	]
+} 

--- a/src/main/resources/assets/abnormals_core/models/block/chain_small_top.json
+++ b/src/main/resources/assets/abnormals_core/models/block/chain_small_top.json
@@ -1,0 +1,29 @@
+{
+	"parent": "block/block",
+	"textures": {
+		"particle": "block/chain",
+		"all": "block/chain"
+	},
+	"elements": [
+		{
+			"from": [6.5, 10, 8],
+			"to": [9.5, 16, 8],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 18, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 6], "texture": "#all"},
+				"south": {"uv": [0, 0, 3, 6], "texture": "#all"}
+			}
+		},
+		{
+			"from": [8, 10, 6.5],
+			"to": [8, 16, 9.5],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 18, 8]},
+			"faces": {
+				"east": {"uv": [3, 0, 6, 6], "texture": "#all"},
+				"west": {"uv": [3, 0, 6, 6], "texture": "#all"}
+			}
+		}
+	]
+} 

--- a/src/main/resources/assets/abnormals_core/models/block/post.json
+++ b/src/main/resources/assets/abnormals_core/models/block/post.json
@@ -1,18 +1,18 @@
 {
     "parent": "minecraft:block/block",
     "textures": {
-        "particle": "#side"
+        "particle": "#texture"
     },
     "elements": [
         {   "from": [ 6, 0, 6 ],
             "to": [ 10, 16, 10 ],
             "faces": {
-                "down":  { "uv": [ 6, 6, 10, 10 ], "texture": "#top", "cullface": "down" },
-                "up":    { "uv": [ 6, 6, 10, 10 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
-                "south": { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
-                "west":  { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
-                "east":  { "uv": [ 6, 0, 10, 16 ], "texture": "#side" }
+                "down":  { "uv": [ 6, 6, 10, 10 ], "texture": "#texture", "cullface": "down" },
+                "up":    { "uv": [ 6, 6, 10, 10 ], "texture": "#texture", "cullface": "up" },
+                "north": { "uv": [ 6, 0, 10, 16 ], "texture": "#texture" },
+                "south": { "uv": [ 6, 0, 10, 16 ], "texture": "#texture" },
+                "west":  { "uv": [ 6, 0, 10, 16 ], "texture": "#texture" },
+                "east":  { "uv": [ 6, 0, 10, 16 ], "texture": "#texture" }
             }
         }
     ]

--- a/src/main/resources/assets/abnormals_core/models/block/post.json
+++ b/src/main/resources/assets/abnormals_core/models/block/post.json
@@ -1,0 +1,19 @@
+{
+    "parent": "minecraft:block/block",
+    "textures": {
+        "particle": "#side"
+    },
+    "elements": [
+        {   "from": [ 6, 0, 6 ],
+            "to": [ 10, 16, 10 ],
+            "faces": {
+                "down":  { "uv": [ 6, 6, 10, 10 ], "texture": "#top", "cullface": "down" },
+                "up":    { "uv": [ 6, 6, 10, 10 ], "texture": "#top", "cullface": "up" },
+                "north": { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
+                "south": { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
+                "west":  { "uv": [ 6, 0, 10, 16 ], "texture": "#side" },
+                "east":  { "uv": [ 6, 0, 10, 16 ], "texture": "#side" }
+            }
+        }
+    ]
+}

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -7,7 +7,7 @@ import com.minecraftabnormals.abnormals_core.common.blocks.chest.AbnormalsTrappe
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsStandingSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsWallSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.AbnormalsLogBlock;
-import com.minecraftabnormals.abnormals_core.common.blocks.wood.WoodPostBlock;
+import com.minecraftabnormals.abnormals_core.common.blocks.wood.StrippedWoodPostBlock;
 import com.minecraftabnormals.abnormals_core.core.annotations.Test;
 import com.minecraftabnormals.abnormals_core.core.util.registry.BlockSubRegistryHelper;
 import common.blocks.ChunkLoadTestBlock;
@@ -38,5 +38,5 @@ public final class TestBlocks {
 
 	public static final RegistryObject<Block> LOG_BLOCK = HELPER.createBlock("log_block", () -> new AbnormalsLogBlock(() -> Blocks.STRIPPED_ACACIA_LOG, AbstractBlock.Properties.create(Material.WOOD, MaterialColor.ADOBE)), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<Block> BEEHIVE = HELPER.createBlock("example_beehive", () -> new AbnormalsBeehiveBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.DECORATIONS);
-	public static final RegistryObject<Block> POST = HELPER.createBlock("post", () -> new WoodPostBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
+	public static final RegistryObject<Block> POST = HELPER.createBlock("post", () -> new StrippedWoodPostBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 }

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -8,6 +8,7 @@ import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsStandin
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsWallSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.AbnormalsLogBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.StrippedWoodPostBlock;
+import com.minecraftabnormals.abnormals_core.common.blocks.wood.WoodPostBlock;
 import com.minecraftabnormals.abnormals_core.core.annotations.Test;
 import com.minecraftabnormals.abnormals_core.core.util.registry.BlockSubRegistryHelper;
 import common.blocks.ChunkLoadTestBlock;
@@ -38,5 +39,6 @@ public final class TestBlocks {
 
 	public static final RegistryObject<Block> LOG_BLOCK = HELPER.createBlock("log_block", () -> new AbnormalsLogBlock(() -> Blocks.STRIPPED_ACACIA_LOG, AbstractBlock.Properties.create(Material.WOOD, MaterialColor.ADOBE)), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<Block> BEEHIVE = HELPER.createBlock("example_beehive", () -> new AbnormalsBeehiveBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.DECORATIONS);
-	public static final RegistryObject<Block> POST = HELPER.createBlock("post", () -> new StrippedWoodPostBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
+	public static final RegistryObject<Block> TEST_STRIPPED_POST = HELPER.createBlock("test_stripped_post", () -> new StrippedWoodPostBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
+	public static final RegistryObject<Block> TEST_POST = HELPER.createBlock("test_post", () -> new WoodPostBlock(TEST_STRIPPED_POST, Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 }

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -7,6 +7,7 @@ import com.minecraftabnormals.abnormals_core.common.blocks.chest.AbnormalsTrappe
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsStandingSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsWallSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.AbnormalsLogBlock;
+import com.minecraftabnormals.abnormals_core.common.blocks.wood.WoodPostBlock;
 import com.minecraftabnormals.abnormals_core.core.annotations.Test;
 import com.minecraftabnormals.abnormals_core.core.util.registry.BlockSubRegistryHelper;
 import common.blocks.ChunkLoadTestBlock;
@@ -37,4 +38,5 @@ public final class TestBlocks {
 
 	public static final RegistryObject<Block> LOG_BLOCK = HELPER.createBlock("log_block", () -> new AbnormalsLogBlock(() -> Blocks.STRIPPED_ACACIA_LOG, AbstractBlock.Properties.create(Material.WOOD, MaterialColor.ADOBE)), ItemGroup.BUILDING_BLOCKS);
 	public static final RegistryObject<Block> BEEHIVE = HELPER.createBlock("example_beehive", () -> new AbnormalsBeehiveBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.DECORATIONS);
+	public static final RegistryObject<Block> POST = HELPER.createBlock("post", () -> new WoodPostBlock(Block.Properties.from(Blocks.DIRT)), ItemGroup.BUILDING_BLOCKS);
 }

--- a/src/test/resources/assets/ac_test/blockstates/test_post.json
+++ b/src/test/resources/assets/ac_test/blockstates/test_post.json
@@ -1,0 +1,55 @@
+{
+  "multipart": [
+    {
+      "when": {
+        "axis": "y"
+      },
+      "apply": {
+        "model": "ac_test:block/test_post"
+      }
+    },
+    {
+      "when": {
+        "axis": "x"
+      },
+      "apply": {
+        "model": "ac_test:block/test_post",
+        "x": 90,
+        "y": 90
+      }
+    },
+    {
+      "when": {
+        "axis": "z"
+      },
+      "apply": {
+        "model": "ac_test:block/test_post",
+        "x": 90
+      }
+    },
+    {   
+    	"when": { "chain_down": true },
+        "apply": { "model": "abnormals_core:block/chain_small" }
+    },
+    {   
+    	"when": { "chain_up": true },
+        "apply": { "model": "abnormals_core:block/chain_small_top" }
+    },
+    {   
+    	"when": { "chain_north": true },
+        "apply": { "model": "abnormals_core:block/chain_small_top", "x": 90 }
+    },
+    {   
+    	"when": { "chain_south": true },
+        "apply": { "model": "abnormals_core:block/chain_small", "x": 90 }
+    },
+    {   
+    	"when": { "chain_east": true },
+        "apply": { "model": "abnormals_core:block/chain_small_top", "x": 90, "y": 90 }
+    },
+    {   
+    	"when": { "chain_west": true },
+        "apply": { "model": "abnormals_core:block/chain_small", "x": 90, "y": 90 }
+    }
+  ]
+} 

--- a/src/test/resources/assets/ac_test/models/block/test_post.json
+++ b/src/test/resources/assets/ac_test/models/block/test_post.json
@@ -1,0 +1,6 @@
+{
+  "parent": "abnormals_core:block/post",
+  "textures": {
+    "texture": "minecraft:block/dirt"
+  }
+} 

--- a/src/test/resources/assets/ac_test/models/item/test_post.json
+++ b/src/test/resources/assets/ac_test/models/item/test_post.json
@@ -1,0 +1,3 @@
+{
+    "parent": "ac_test:block/test_post"
+} 


### PR DESCRIPTION
Quark's wooden posts were recently revamped to allow them to be placed on all 3 axes and connect with chains and lanterns. This PR contains changes to AC's wooden posts so that they can do the same.