### PR TITLE
Remove unused imports

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/common/blocks/BookshelfBlock.java
@@ -2,9 +2,7 @@ package com.minecraftabnormals.abnormals_core.common.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorldReader;
 
 public class BookshelfBlock extends Block {

--- a/src/test/java/core/registry/TestBlocks.java
+++ b/src/test/java/core/registry/TestBlocks.java
@@ -8,7 +8,6 @@ import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsStandin
 import com.minecraftabnormals.abnormals_core.common.blocks.sign.AbnormalsWallSignBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.AbnormalsLogBlock;
 import com.minecraftabnormals.abnormals_core.common.blocks.wood.WoodPostBlock;
-import com.minecraftabnormals.abnormals_core.common.blocks.wood.WoodPostBlock;
 import com.minecraftabnormals.abnormals_core.core.annotations.Test;
 import com.minecraftabnormals.abnormals_core.core.util.registry.BlockSubRegistryHelper;
 import common.blocks.ChunkLoadTestBlock;


### PR DESCRIPTION
This was bothering my IDE and it seems I accidentally imported `WoodPostBlock` twice in my previous PR, so this is a PR to remove all the unused imports across the project.