### PR TITLE
[1.16.5] Added Chlorine Compatibility

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/ACMixinPlugin.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/ACMixinPlugin.java
@@ -1,0 +1,44 @@
+package com.minecraftabnormals.abnormals_core.core.mixin;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class ACMixinPlugin implements IMixinConfigPlugin {
+    private boolean chlorineLoaded;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        try {
+            Class.forName("dev.hanetzer.chlorine.common.Chlorine"); // Checks if Chlorine's main class is available since mods haven't loaded at this stage
+            this.chlorineLoaded = true;
+        } catch (ClassNotFoundException ignored) {}
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return chlorineLoaded ? !mixinClassName.equals("com.minecraftabnormals.abnormals_core.core.mixin.compat.client.ClientWorldVanillaMixin") : !mixinClassName.equals("com.minecraftabnormals.abnormals_core.core.mixin.compat.client.ClientWorldChlorineMixin");
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/client/ClientWorldMixin.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/client/ClientWorldMixin.java
@@ -42,20 +42,6 @@ public abstract class ClientWorldMixin extends World {
         super(p_i241925_1_, p_i241925_2_, p_i241925_3_, p_i241925_4_, p_i241925_5_, p_i241925_6_, p_i241925_7_);
     }
 
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;animateTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V"), method = "animateTick(IIIILjava/util/Random;ZLnet/minecraft/util/math/BlockPos$Mutable;)V")
-    private void animateTick(Block block, BlockState state, World world, BlockPos pos, Random rand) {
-        if (!AnimateTickEvent.onAnimateTick(state, world, pos, rand)) {
-            block.animateTick(state, world, pos, rand);
-        }
-    }
-
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/fluid/FluidState;animateTick(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V"), method = "animateTick(IIIILjava/util/Random;ZLnet/minecraft/util/math/BlockPos$Mutable;)V")
-    private void animateFluidTick(FluidState state, World world, BlockPos pos, Random random) {
-        if (!AnimateFluidTickEvent.onAnimateFluidTick(world, pos, state, random)) {
-            ((FluidInvokerMixin) state.getFluid()).callAnimateTick(world, pos, state, random);
-        }
-    }
-
     @Inject(at = @At("HEAD"), method = "getSkyColor", cancellable = true)
     private void getSkyColor(BlockPos blockPos, float partialTicks, CallbackInfoReturnable<Vector3d> info) {
         if (ACConfig.ValuesHolder.isSmoothSkyColorEnabled() && this.field_239131_x_.func_241683_c_() == DimensionRenderInfo.FogType.NORMAL) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/compat/client/ClientWorldChlorineMixin.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/compat/client/ClientWorldChlorineMixin.java
@@ -1,0 +1,35 @@
+package com.minecraftabnormals.abnormals_core.core.mixin.compat.client;
+
+import com.minecraftabnormals.abnormals_core.core.events.AnimateFluidTickEvent;
+import com.minecraftabnormals.abnormals_core.core.events.AnimateTickEvent;
+import com.minecraftabnormals.abnormals_core.core.mixin.FluidInvokerMixin;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+
+@Mixin(value = ClientWorld.class, priority = 1001)
+public final class ClientWorldChlorineMixin {
+
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;animateTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V"), method = "performBlockDisplayTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;Z)V")
+    private void animateTick(Block block, BlockState state, World world, BlockPos pos, Random rand) {
+        if (!AnimateTickEvent.onAnimateTick(state, world, pos, rand)) {
+            block.animateTick(state, world, pos, rand);
+        }
+    }
+
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/fluid/FluidState;animateTick(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V"), method = "performFluidDisplayTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/fluid/FluidState;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V")
+    private void animateFluidTick(FluidState state, World world, BlockPos pos, Random random) {
+        if (!AnimateFluidTickEvent.onAnimateFluidTick(world, pos, state, random)) {
+            ((FluidInvokerMixin) state.getFluid()).callAnimateTick(world, pos, state, random);
+        }
+    }
+
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/compat/client/ClientWorldVanillaMixin.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/mixin/compat/client/ClientWorldVanillaMixin.java
@@ -1,0 +1,35 @@
+package com.minecraftabnormals.abnormals_core.core.mixin.compat.client;
+
+import com.minecraftabnormals.abnormals_core.core.events.AnimateFluidTickEvent;
+import com.minecraftabnormals.abnormals_core.core.events.AnimateTickEvent;
+import com.minecraftabnormals.abnormals_core.core.mixin.FluidInvokerMixin;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+
+@Mixin(value = ClientWorld.class, priority = 1001)
+public final class ClientWorldVanillaMixin {
+
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;animateTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V"), method = "animateTick(IIIILjava/util/Random;ZLnet/minecraft/util/math/BlockPos$Mutable;)V")
+    private void animateTick(Block block, BlockState state, World world, BlockPos pos, Random rand) {
+        if (!AnimateTickEvent.onAnimateTick(state, world, pos, rand)) {
+            block.animateTick(state, world, pos, rand);
+        }
+    }
+
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/fluid/FluidState;animateTick(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Ljava/util/Random;)V"), method = "animateTick(IIIILjava/util/Random;ZLnet/minecraft/util/math/BlockPos$Mutable;)V")
+    private void animateFluidTick(FluidState state, World world, BlockPos pos, Random random) {
+        if (!AnimateFluidTickEvent.onAnimateFluidTick(world, pos, state, random)) {
+            ((FluidInvokerMixin) state.getFluid()).callAnimateTick(world, pos, state, random);
+        }
+    }
+
+}

--- a/src/main/resources/abnormals_core.mixins.json
+++ b/src/main/resources/abnormals_core.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "com.minecraftabnormals.abnormals_core.core.mixin",
+  "plugin": "com.minecraftabnormals.abnormals_core.core.mixin.ACMixinPlugin",
   "compatibilityLevel": "JAVA_8",
   "minVersion": "0.8",
   "refmap": "abnormals_core.refmap.json",
@@ -18,10 +19,12 @@
     "TrapDoorBlockMixin"
   ],
   "client": [
+    "compat.client.ClientWorldChlorineMixin",
     "client.ClientWorldMixin",
+    "compat.client.ClientWorldVanillaMixin",
     "client.CustomizeSkinScreenMixin",
-    "client.PlayerRendererMixin",
-    "client.MinecraftMixin"
+    "client.MinecraftMixin",
+    "client.PlayerRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR adds compatibility for Chlorine which fixes it from crashing and still retains `AnimateTickEvent` and `AnimateFluidTickEvent`.

I've added compatibility by moving the `animateTick` redirects into two mixins, `ClientWorldVanillaMixin` and `ClientWorldChlorineMixin`, which target the correct `animateTick` methods and then using a mixin plugin, I've loaded one or the other based on if Chlorine's main class is available (read comment in `ACMixinPlugin` for more info).

Now there are some side-effects to this, if Chlorine were to remove or rename their methods (`performBlockDisplayTick` and `performFluidDisplayTick`) it'll start crashing again as I have no way of checking the version of Chlorine. Though I highly doubt these methods will change at all and this is better than it crashing currently.

Obviously this isn't the greatest fix, preferably it should be done on Chlorine's side, but this is better than nothing for the moment.

Fixes #82 