### PR TITLE
Added config, raid check and random difficulty chance loot conditions

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
@@ -15,8 +15,11 @@ import com.minecraftabnormals.abnormals_core.core.api.conditions.config.GreaterT
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.LessThanOrEqualPredicate;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.LessThanPredicate;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.MatchesPredicate;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ACAndRecipeCondition;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.QuarkFlagRecipeCondition;
 import com.minecraftabnormals.abnormals_core.core.api.model.FullbrightModel;
 import com.minecraftabnormals.abnormals_core.core.registry.ACEntities;
+import com.minecraftabnormals.abnormals_core.core.registry.ACLootConditions;
 import com.minecraftabnormals.abnormals_core.core.registry.ACTileEntities;
 import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.NetworkUtil;
@@ -27,7 +30,6 @@ import com.minecraftabnormals.abnormals_core.common.capability.chunkloading.Chun
 import com.minecraftabnormals.abnormals_core.common.network.*;
 import com.minecraftabnormals.abnormals_core.common.network.entity.*;
 import com.minecraftabnormals.abnormals_core.common.network.particle.*;
-import com.minecraftabnormals.abnormals_core.core.api.conditions.*;
 import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
 import com.minecraftabnormals.abnormals_core.core.endimator.EndimationDataManager;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
@@ -135,7 +137,10 @@ public final class AbnormalsCore {
 	}
 
 	private void commonSetup(FMLCommonSetupEvent event) {
-		event.enqueueWork(this::replaceBeehivePOI);
+		event.enqueueWork(() -> {
+			this.replaceBeehivePOI();
+			ACLootConditions.registerLootConditions();
+		});
 		ChunkLoaderCapability.register();
 		TrackedDataManager.INSTANCE.registerData(new ResourceLocation(MODID, "slabfish_head"), SLABFISH_SETTINGS);
 	}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/annotations/ConfigKey.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/annotations/ConfigKey.java
@@ -1,6 +1,6 @@
 package com.minecraftabnormals.abnormals_core.core.annotations;
 
-import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * This annotation, when applied to {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue ConfigValue} fields
  * in objects that are passed into the {@code Object...} parameter of
  * {@link com.minecraftabnormals.abnormals_core.core.util.DataUtil#registerConfigCondition(String, Object...) registerConfigCondition},
- * allows the value to be referred to in JSON by a {@link ConfigCondition ConfigCondition}
+ * allows the value to be referred to in JSON by a {@link ConfigValueCondition ConfigValueCondition}
  * or {@link com.minecraftabnormals.abnormals_core.core.api.conditions.loot.ConfigLootCondition ConfigLootCondition} matching
  * the mod ID passed into {@link com.minecraftabnormals.abnormals_core.core.util.DataUtil#registerConfigCondition(String, Object...) registerConfigCondition}.
  *

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/annotations/ConfigKey.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/annotations/ConfigKey.java
@@ -1,5 +1,7 @@
 package com.minecraftabnormals.abnormals_core.core.annotations;
 
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -10,10 +12,9 @@ import java.lang.annotation.Target;
  * This annotation, when applied to {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue ConfigValue} fields
  * in objects that are passed into the {@code Object...} parameter of
  * {@link com.minecraftabnormals.abnormals_core.core.util.DataUtil#registerConfigCondition(String, Object...) registerConfigCondition},
- * allows the value to be referred to in JSON by a
- * {@link com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition ConfigValueCondition} matching
- * the mod ID passed into {@link com.minecraftabnormals.abnormals_core.core.util.DataUtil#registerConfigCondition(String, Object...) registerConfigCondition},
- * which can then be used to test a condition.
+ * allows the value to be referred to in JSON by a {@link ConfigCondition ConfigCondition}
+ * or {@link com.minecraftabnormals.abnormals_core.core.api.conditions.loot.ConfigLootCondition ConfigLootCondition} matching
+ * the mod ID passed into {@link com.minecraftabnormals.abnormals_core.core.util.DataUtil#registerConfigCondition(String, Object...) registerConfigCondition}.
  *
  * <p>The {@code value} of this annotation determines what string needs to be specified in a config condition to get the
  * value associated with its field. For example, if you had a class like this:

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/ConfigValueCondition.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/ConfigValueCondition.java
@@ -39,14 +39,14 @@ import java.util.Map;
  * @see DataUtil#registerConfigCondition(String, Object...)
  * @author abigailfails
  */
-public class ConfigCondition implements ICondition {
+public class ConfigValueCondition implements ICondition {
     private final ForgeConfigSpec.ConfigValue<?> value;
     private final String valueID;
     private final Map<IConfigPredicate, Boolean> predicates;
     private final boolean inverted;
     private final ResourceLocation location;
 
-    public ConfigCondition(ResourceLocation location, ForgeConfigSpec.ConfigValue<?> value, String valueID, Map<IConfigPredicate, Boolean> predicates, boolean inverted) {
+    public ConfigValueCondition(ResourceLocation location, ForgeConfigSpec.ConfigValue<?> value, String valueID, Map<IConfigPredicate, Boolean> predicates, boolean inverted) {
         this.location = location;
         this.value = value;
         this.valueID = valueID;
@@ -70,7 +70,7 @@ public class ConfigCondition implements ICondition {
         return this.inverted != returnValue;
     }
 
-    public static class Serializer implements IConditionSerializer<ConfigCondition> {
+    public static class Serializer implements IConditionSerializer<ConfigValueCondition> {
         public static final Hashtable<ResourceLocation, IConfigPredicateSerializer<?>> CONFIG_PREDICATE_SERIALIZERS = new Hashtable<>();
         private final Map<String, ForgeConfigSpec.ConfigValue<?>> configValues;
         private final ResourceLocation location;
@@ -81,7 +81,7 @@ public class ConfigCondition implements ICondition {
         }
 
         @Override
-        public void write(JsonObject json, ConfigCondition value) {
+        public void write(JsonObject json, ConfigValueCondition value) {
             json.addProperty("value", value.valueID);
             if (!value.predicates.isEmpty()) {
                 JsonArray predicates = new JsonArray();
@@ -100,7 +100,7 @@ public class ConfigCondition implements ICondition {
         }
 
         @Override
-        public ConfigCondition read(JsonObject json) {
+        public ConfigValueCondition read(JsonObject json) {
             if (!json.has("value"))
                 throw new JsonSyntaxException("Missing 'value', expected to find a string");
             String name = JSONUtils.getString(json, "value");
@@ -122,7 +122,7 @@ public class ConfigCondition implements ICondition {
             } else if (!(configValue.get() instanceof Boolean)) {
                 throw new JsonSyntaxException("Missing 'predicates' for non-boolean config value '" + name + "', expected to find an array");
             }
-            return new ConfigCondition(location, configValue, name, predicates, json.has("inverted") && JSONUtils.getBoolean(json, "inverted"));
+            return new ConfigValueCondition(location, configValue, name, predicates, json.has("inverted") && JSONUtils.getBoolean(json, "inverted"));
         }
 
         @Override

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/ConfigValueCondition.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/ConfigValueCondition.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 /**
  * A condition that checks against the values of config values annotated with {@link ConfigKey}. Uses the recipe system,
- * but is also compatible with advancement modifiers etc.
+ * but is also compatible with modifiers etc.
  *
  * <p>To make your mod's config values compatible with it, annotate them with {@link ConfigKey} taking in the string
  * value that should be used to deserialize the field, then call {@link DataUtil#registerConfigCondition(String, Object...)}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/config/IConfigPredicate.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/config/IConfigPredicate.java
@@ -1,11 +1,11 @@
 package com.minecraftabnormals.abnormals_core.core.api.conditions.config;
 
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.ForgeConfigSpec;
-import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
 
 /**
- * A predicate for a {@link ConfigCondition}, takes in a
+ * A predicate for a {@link ConfigValueCondition}, takes in a
  * {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue} and returns a boolean for whether it matches the condition.
  *
  */

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/config/IConfigPredicate.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/config/IConfigPredicate.java
@@ -2,10 +2,10 @@ package com.minecraftabnormals.abnormals_core.core.api.conditions.config;
 
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.ForgeConfigSpec;
-import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
 
 /**
- * A predicate for a {@link ConfigValueCondition}, takes in a
+ * A predicate for a {@link ConfigCondition}, takes in a
  * {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue} and returns a boolean for whether it matches the condition.
  *
  */

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/ConfigLootCondition.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/ConfigLootCondition.java
@@ -6,9 +6,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSyntaxException;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicate;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicateSerializer;
-import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
 import net.minecraft.loot.ILootSerializer;
 import net.minecraft.loot.LootConditionType;
 import net.minecraft.loot.LootContext;
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A loot condition that is registered and functions exactly the same way as {@link ConfigCondition}, but for loot tables instead.
+ * A loot condition that is registered and functions exactly the same way as {@link ConfigValueCondition}, but for loot tables instead.
  *
  * @author abigailfails
  */
@@ -78,7 +78,7 @@ public class ConfigLootCondition implements ILootCondition {
                     JsonObject object = new JsonObject();
                     predicates.add(object);
                     object.addProperty("type", predicateID.toString());
-                    ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.get(predicateID).write(object, predicate);
+                    ConfigValueCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.get(predicateID).write(object, predicate);
                     object.addProperty("inverted", predicatePair.getValue());
                 }
             }
@@ -100,7 +100,7 @@ public class ConfigLootCondition implements ILootCondition {
                         throw new JsonSyntaxException("Predicates must be an array of JsonObjects");
                     JsonObject predicateObject = predicateElement.getAsJsonObject();
                     ResourceLocation type = new ResourceLocation(JSONUtils.getString(predicateObject, "type"));
-                    IConfigPredicateSerializer<?> serializer = ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.get(type);
+                    IConfigPredicateSerializer<?> serializer = ConfigValueCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.get(type);
                     if (serializer == null)
                         throw new JsonSyntaxException("Unknown predicate type: " + type.toString());
                     predicates.put(serializer.read(predicateObject), predicateObject.has("inverted") && JSONUtils.getBoolean(predicateObject, "inverted"));

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/ConfigLootCondition.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/ConfigLootCondition.java
@@ -1,0 +1,114 @@
+package com.minecraftabnormals.abnormals_core.core.api.conditions.loot;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSyntaxException;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicate;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicateSerializer;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
+import net.minecraft.loot.ILootSerializer;
+import net.minecraft.loot.LootConditionType;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.conditions.ILootCondition;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+import net.minecraftforge.common.ForgeConfigSpec;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A loot condition that is registered and functions exactly the same way as {@link ConfigCondition}, but for loot tables instead.
+ *
+ * @author abigailfails
+ */
+public class ConfigLootCondition implements ILootCondition {
+    private final ForgeConfigSpec.ConfigValue<?> value;
+    private final String valueID;
+    private final Map<IConfigPredicate, Boolean> predicates;
+    private final boolean inverted;
+    private final ResourceLocation location;
+
+    public ConfigLootCondition(ResourceLocation location, ForgeConfigSpec.ConfigValue<?> value, String valueID, Map<IConfigPredicate, Boolean> predicates, boolean inverted) {
+        this.location = location;
+        this.value = value;
+        this.valueID = valueID;
+        this.predicates = predicates;
+        this.inverted = inverted;
+    }
+
+    @Override
+    public LootConditionType func_230419_b_() {
+        return Registry.LOOT_CONDITION_TYPE.getOrDefault(this.location);
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        boolean returnValue;
+        if (predicates.size() > 0) {
+            returnValue = this.predicates.keySet().stream().allMatch(c -> this.predicates.get(c) != c.test(value));
+        } else if (value.get() instanceof Boolean) {
+            returnValue = (Boolean) value.get();
+        } else throw new IllegalStateException("Predicates required for non-boolean ConfigLootCondition, but none found");
+        return this.inverted != returnValue;
+    }
+
+    public static class Serializer implements ILootSerializer<ConfigLootCondition> {
+        private final Map<String, ForgeConfigSpec.ConfigValue<?>> configValues;
+        private final ResourceLocation location;
+
+        public Serializer(String modId, Map<String, ForgeConfigSpec.ConfigValue<?>> configValues) {
+            this.location = new ResourceLocation(modId, "config");
+            this.configValues = configValues;
+        }
+
+        @Override
+        public void serialize(JsonObject json, ConfigLootCondition value, JsonSerializationContext context) {
+            json.addProperty("value", value.valueID);
+            if (!value.predicates.isEmpty()) {
+                JsonArray predicates = new JsonArray();
+                json.add("predicates", predicates);
+                for (Map.Entry<IConfigPredicate, Boolean> predicatePair : value.predicates.entrySet()) {
+                    IConfigPredicate predicate = predicatePair.getKey();
+                    ResourceLocation predicateID = predicate.getID();
+                    JsonObject object = new JsonObject();
+                    predicates.add(object);
+                    object.addProperty("type", predicateID.toString());
+                    ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.get(predicateID).write(object, predicate);
+                    object.addProperty("inverted", predicatePair.getValue());
+                }
+            }
+            if (value.inverted) json.addProperty("inverted", true);
+        }
+
+        @Override
+        public ConfigLootCondition deserialize(JsonObject json, JsonDeserializationContext context) {
+            if (!json.has("value"))
+                throw new JsonSyntaxException("Missing 'value', expected to find a string");
+            String name = JSONUtils.getString(json, "value");
+            ForgeConfigSpec.ConfigValue<?> configValue = configValues.get(name);
+            if (configValue == null)
+                throw new JsonSyntaxException("No config value of name '" + name + "' found");
+            Map<IConfigPredicate, Boolean> predicates = new HashMap<>();
+            if (JSONUtils.hasField(json, "predicates")) {
+                for (JsonElement predicateElement : JSONUtils.getJsonArray(json, "predicates")) {
+                    if (!predicateElement.isJsonObject())
+                        throw new JsonSyntaxException("Predicates must be an array of JsonObjects");
+                    JsonObject predicateObject = predicateElement.getAsJsonObject();
+                    ResourceLocation type = new ResourceLocation(JSONUtils.getString(predicateObject, "type"));
+                    IConfigPredicateSerializer<?> serializer = ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.get(type);
+                    if (serializer == null)
+                        throw new JsonSyntaxException("Unknown predicate type: " + type.toString());
+                    predicates.put(serializer.read(predicateObject), predicateObject.has("inverted") && JSONUtils.getBoolean(predicateObject, "inverted"));
+                }
+            } else if (!(configValue.get() instanceof Boolean)) {
+                throw new JsonSyntaxException("Missing 'predicates' for non-boolean config value '" + name + "', expected to find an array");
+            }
+            return new ConfigLootCondition(location, configValue, name, predicates, json.has("inverted") && JSONUtils.getBoolean(json, "inverted"));
+        }
+    }
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/RaidCheckCondition.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/RaidCheckCondition.java
@@ -1,0 +1,54 @@
+package com.minecraftabnormals.abnormals_core.core.api.conditions.loot;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.minecraftabnormals.abnormals_core.core.registry.ACLootConditions;
+import net.minecraft.entity.Entity;
+import net.minecraft.loot.ILootSerializer;
+import net.minecraft.loot.LootConditionType;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.LootParameters;
+import net.minecraft.loot.conditions.ILootCondition;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.registry.Registry;
+
+/**
+ * A loot condition that passes if there is a raid at the entity's position.
+ *
+ <p>Arguments:
+ * <ul>
+ *   <li>{@code inverted} (optional) - whether the condition should be inverted, so it will pass if there is not a raid instead.</li>
+ * </ul></p>
+ * @author abigailfails
+ */
+public class RaidCheckCondition implements ILootCondition {
+    private final boolean inverted;
+
+    public RaidCheckCondition(boolean inverted) {
+        this.inverted = inverted;
+    }
+
+    @Override
+    public LootConditionType func_230419_b_() {
+        return Registry.LOOT_CONDITION_TYPE.getOrDefault(ACLootConditions.RAID_CHECK);
+    }
+
+    @Override
+    public boolean test(LootContext lootContext) {
+        Entity entity = lootContext.get(LootParameters.THIS_ENTITY);
+        return inverted != (entity != null && lootContext.getWorld().findRaid(entity.getPosition()) != null);
+    }
+
+    public static class Serializer implements ILootSerializer<RaidCheckCondition> {
+
+        public void serialize(JsonObject json, RaidCheckCondition condition, JsonSerializationContext context) {
+            if (condition.inverted)
+                json.addProperty("inverted", true);
+        }
+
+        public RaidCheckCondition deserialize(JsonObject json, JsonDeserializationContext context) {
+            return new RaidCheckCondition(JSONUtils.getBoolean(json, "inverted", false));
+        }
+    }
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/RandomDifficultyChanceCondition.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/api/conditions/loot/RandomDifficultyChanceCondition.java
@@ -1,0 +1,97 @@
+package com.minecraftabnormals.abnormals_core.core.api.conditions.loot;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSyntaxException;
+import com.minecraftabnormals.abnormals_core.core.registry.ACLootConditions;
+import net.minecraft.loot.ILootSerializer;
+import net.minecraft.loot.LootConditionType;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.conditions.ILootCondition;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.registry.Registry;
+
+/**
+ * A loot condition that defines a probability based on the current difficulty. Works the same as
+ * {@code random_difficulty_chance} in Bedrock edition.
+ *
+ * <p>Arguments:
+ * <ul>
+ *   <li>{@code default_chance} (required) - the float chance to fall back on if the difficulty is set a value
+ *                                           other than those specified in the arguments.</li>
+ *   <li>{@code hard} - the float chance to use if the difficulty is set to Hard.</li>
+ *   <li>{@code normal} - the float chance to use if the difficulty is set to Normal.</li>
+ *   <li>{@code easy} - the float chance to use if the difficulty is set to Easy.</li>
+ *   <li>{@code peaceful} - the float chance to use if the difficulty is set to Peaceful.</li>
+ * </ul></p>
+ *
+ * @author abigailfails
+ */
+public class RandomDifficultyChanceCondition implements ILootCondition {
+	private final float defaultChance;
+	private final float peacefulChance;
+	private final float easyChance;
+	private final float normalChance;
+	private final float hardChance;
+
+	public RandomDifficultyChanceCondition(float defaultChance, float peacefulChance, float easyChance, float normalChance, float hardChance) {
+		this.peacefulChance = peacefulChance;
+		this.defaultChance = defaultChance;
+		this.easyChance = easyChance;
+		this.normalChance = normalChance;
+		this.hardChance = hardChance;
+	}
+
+	@Override
+	public LootConditionType func_230419_b_() {
+		return Registry.LOOT_CONDITION_TYPE.getOrDefault(ACLootConditions.RANDOM_DIFFICULTY_CHANCE);
+	}
+
+	@Override
+	public boolean test(LootContext lootContext) {
+		float chance = this.defaultChance;
+		switch (lootContext.getWorld().getDifficulty()) {
+			case PEACEFUL:
+				if (this.peacefulChance >= 0) chance = this.peacefulChance;
+				break;
+			case EASY:
+				if (this.easyChance >= 0) chance = this.easyChance;
+				break;
+			case NORMAL:
+				if (this.normalChance >= 0) chance = this.normalChance;
+				break;
+			case HARD:
+				if (this.hardChance >= 0) chance = this.hardChance;
+
+		}
+		return lootContext.getRandom().nextFloat() < chance;
+	}
+
+	public static class Serializer implements ILootSerializer<RandomDifficultyChanceCondition> {
+		public void serialize(JsonObject json, RandomDifficultyChanceCondition condition, JsonSerializationContext context) {
+			json.addProperty("default_chance", condition.defaultChance);
+			if (condition.peacefulChance >= 0)
+				json.addProperty("peaceful", condition.peacefulChance);
+			if (condition.easyChance >= 0)
+				json.addProperty("easy", condition.easyChance);
+			if (condition.normalChance >= 0)
+				json.addProperty("normal", condition.normalChance);
+			if (condition.hardChance >= 0)
+				json.addProperty("hard", condition.hardChance);
+		}
+
+		public RandomDifficultyChanceCondition deserialize(JsonObject json, JsonDeserializationContext context) {
+			if (json.has("default_chance")) {
+				return new RandomDifficultyChanceCondition(JSONUtils.getFloat(json, "default_chance"), getFloatOrMinus1(json, "peaceful"), getFloatOrMinus1(json, "easy"), getFloatOrMinus1(json, "normal"), getFloatOrMinus1(json, "hard"));
+			}
+			throw new JsonSyntaxException("Missing 'default_chance', expected to find a float");
+		}
+
+		private static float getFloatOrMinus1(JsonObject json, String fieldName) {
+			if (json.has(fieldName))
+				return JSONUtils.getFloat(json, fieldName);
+			return -1;
+		}
+	}
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/registry/ACLootConditions.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/registry/ACLootConditions.java
@@ -8,6 +8,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
 
 /**
+ * Registers a few loot conditions made for general use by mods and datapack creators.
+ *
  * @author abigailfails
  */
 public final class ACLootConditions {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/registry/ACLootConditions.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/registry/ACLootConditions.java
@@ -1,0 +1,21 @@
+package com.minecraftabnormals.abnormals_core.core.registry;
+
+import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.loot.RaidCheckCondition;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.loot.RandomDifficultyChanceCondition;
+import net.minecraft.loot.LootConditionType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+
+/**
+ * @author abigailfails
+ * */
+public class ACLootConditions {
+    public static final ResourceLocation RANDOM_DIFFICULTY_CHANCE = new ResourceLocation(AbnormalsCore.MODID, "random_difficulty_chance");
+    public static final ResourceLocation RAID_CHECK = new ResourceLocation(AbnormalsCore.MODID, "raid_check");
+
+    public static void registerLootConditions() {
+        Registry.register(Registry.LOOT_CONDITION_TYPE, RANDOM_DIFFICULTY_CHANCE, new LootConditionType(new RandomDifficultyChanceCondition.Serializer()));
+        Registry.register(Registry.LOOT_CONDITION_TYPE, RAID_CHECK, new LootConditionType(new RaidCheckCondition.Serializer()));
+    }
+}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/registry/ACLootConditions.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/registry/ACLootConditions.java
@@ -8,7 +8,9 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
 
 /**
- * Registers a few loot conditions made for general use by mods and datapack creators.
+ * Registry class for Abnormal Core's built-in loot conditions.
+ *
+ * <p>These conditions can be used by mods and datapacks.</p>
  *
  * @author abigailfails
  */

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -1,6 +1,5 @@
 package com.minecraftabnormals.abnormals_core.core.util;
 
-import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
 import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.loot.ConfigLootCondition;

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -302,7 +302,7 @@ public final class DataUtil {
 			}
 		}
 		CraftingHelper.register(new ConfigValueCondition.Serializer(modId, configValues));
-		Registry.register(Registry.LOOT_CONDITION_TYPE, new ResourceLocation(AbnormalsCore.MODID, "config"), new LootConditionType(new ConfigLootCondition.Serializer(modId, configValues)));
+		Registry.register(Registry.LOOT_CONDITION_TYPE, new ResourceLocation(modId, "config"), new LootConditionType(new ConfigLootCondition.Serializer(modId, configValues)));
 	}
 
 	/**

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -1,7 +1,9 @@
 package com.minecraftabnormals.abnormals_core.core.util;
 
+import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
 import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
-import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.loot.ConfigLootCondition;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicateSerializer;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.block.Block;
@@ -20,12 +22,14 @@ import net.minecraft.entity.ai.brain.task.GiveHeroGiftsTask;
 import net.minecraft.entity.merchant.villager.VillagerProfession;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.loot.LootConditionType;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionBrewing;
 import net.minecraft.util.IItemProvider;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Util;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.WorldGenRegistries;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
@@ -36,14 +40,11 @@ import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.registries.ForgeRegistries;
 
-import javax.management.ImmutableDescriptor;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.function.BiPredicate;
 
@@ -218,14 +219,14 @@ public final class DataUtil {
 	}
 
 	/**
-	 * Registers a {@link ConfigValueCondition.Serializer} under the name {@code "[modId]:config"}
+	 * Registers a {@link ConfigCondition.Serializer} and a {@link ConfigLootCondition.Serializer} under the name {@code "[modId]:config"}
 	 * that accepts the values of {@link ConfigKey} annotations for {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue}
 	 * fields in the passed-in collection of objects, checking against the annotation's corresponding
 	 * {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue} to determine whether the condition should pass.<br><br>
 	 * <h2>Function</h2>
-	 * <p>This method allows you to make crafting recipes, advancement modifiers, etc. check whether a specific config
+	 * <p>This method allows you to make crafting recipes, advancement modifiers, loot tables, etc. check whether a specific config
 	 * field is true/whether it meets specific predicates before loading without having to hardcode new condition classes
-	 * for certain config values. It's essentially a wrapper for {@link CraftingHelper#register(IConditionSerializer)}
+	 * for certain config values. It's essentially a wrapper for the condition and loot condition registry methods and
 	 * and should be called during common setup accordingly.</p><br><br>
 	 *
 	 * <h2>Implementation</h2>
@@ -250,10 +251,12 @@ public final class DataUtil {
 	 * ]
 	 * }</pre>
 	 *
-	 * <p>Config conditions also accept a {@code predicates} array which defines predicates the config value must match
-	 * before the condition returns true, and a boolean {@code inverted} argument which makes the condition pass if it
-	 * evaluates to false instead of true. If the config value is non-boolean, {@code predicates} is required.
-	 * Each individual predicate also accepts an {@code inverted} argument, as {@code !(A.B) != !A.!B}.</p>
+	 * <p>Config conditions also accept a {@code predicates} array which defines
+	 * {@link com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicate IConfigPredicate}s the
+	 * config value must match before the condition returns true, and a boolean {@code inverted} argument which makes
+	 * the condition pass if it evaluates to false instead of true. If the config value is non-boolean,
+	 * {@code predicates} is required. Each individual predicate also accepts an {@code inverted} argument (as
+	 * {@code !(A.B) != !A.!B}).</p>
 	 *
 	 * <p>For example, you could check whether a the float config value {@code "potato_poison_chance"} is less than
 	 * 0.1 by using the {@code "abnormals_core:greater_than_or_equal_to"} predicate and inverting it. (Of course,
@@ -299,12 +302,13 @@ public final class DataUtil {
 				}
 			}
 		}
-		CraftingHelper.register(new ConfigValueCondition.Serializer(modId, configValues));
+		CraftingHelper.register(new ConfigCondition.Serializer(modId, configValues));
+		Registry.register(Registry.LOOT_CONDITION_TYPE, new ResourceLocation(AbnormalsCore.MODID, "config"), new LootConditionType(new ConfigLootCondition.Serializer(modId, configValues)));
 	}
 
 	/**
 	 * Registers an {@link IConfigPredicateSerializer} for an
-	 * {@link com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicate}.
+	 * {@link com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicate IConfigPredicate}.
 	 *
 	 * <p>The predicate takes in a {@link ForgeConfigSpec.ConfigValue} and returns true if it matches specific conditions.</p>
 	 *
@@ -312,8 +316,8 @@ public final class DataUtil {
 	 */
 	public static void registerConfigPredicate(IConfigPredicateSerializer<?> serializer) {
 		ResourceLocation key = serializer.getID();
-		if (ConfigValueCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.containsKey(key))
+		if (ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.containsKey(key))
 			throw new IllegalStateException("Duplicate config predicate serializer: " + key);
-		ConfigValueCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.put(key, serializer);
+		ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.put(key, serializer);
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -2,8 +2,8 @@ package com.minecraftabnormals.abnormals_core.core.util;
 
 import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
 import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
+import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigValueCondition;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.loot.ConfigLootCondition;
-import com.minecraftabnormals.abnormals_core.core.api.conditions.ConfigCondition;
 import com.minecraftabnormals.abnormals_core.core.api.conditions.config.IConfigPredicateSerializer;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.block.Block;
@@ -35,7 +35,6 @@ import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.crafting.CraftingHelper;
-import net.minecraftforge.common.crafting.conditions.IConditionSerializer;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -219,7 +218,7 @@ public final class DataUtil {
 	}
 
 	/**
-	 * Registers a {@link ConfigCondition.Serializer} and a {@link ConfigLootCondition.Serializer} under the name {@code "[modId]:config"}
+	 * Registers a {@link ConfigValueCondition.Serializer} and a {@link ConfigLootCondition.Serializer} under the name {@code "[modId]:config"}
 	 * that accepts the values of {@link ConfigKey} annotations for {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue}
 	 * fields in the passed-in collection of objects, checking against the annotation's corresponding
 	 * {@link net.minecraftforge.common.ForgeConfigSpec.ConfigValue} to determine whether the condition should pass.<br><br>
@@ -302,7 +301,7 @@ public final class DataUtil {
 				}
 			}
 		}
-		CraftingHelper.register(new ConfigCondition.Serializer(modId, configValues));
+		CraftingHelper.register(new ConfigValueCondition.Serializer(modId, configValues));
 		Registry.register(Registry.LOOT_CONDITION_TYPE, new ResourceLocation(AbnormalsCore.MODID, "config"), new LootConditionType(new ConfigLootCondition.Serializer(modId, configValues)));
 	}
 
@@ -316,8 +315,8 @@ public final class DataUtil {
 	 */
 	public static void registerConfigPredicate(IConfigPredicateSerializer<?> serializer) {
 		ResourceLocation key = serializer.getID();
-		if (ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.containsKey(key))
+		if (ConfigValueCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.containsKey(key))
 			throw new IllegalStateException("Duplicate config predicate serializer: " + key);
-		ConfigCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.put(key, serializer);
+		ConfigValueCondition.Serializer.CONFIG_PREDICATE_SERIALIZERS.put(key, serializer);
 	}
 }


### PR DESCRIPTION
Finally got around to doing this! The config loot condition was just added because i realised the 'normal' condition type isn't compatible with loot tables, and the random difficulty and raid conditions should be generally useful in the future. I'm also going to need them to convert some hardcoded loot table stuff into fully data-driven modifiers in S&R once those are done :P

I'm still a bit iffy about the documentation, so tell me if you see anything wrong with that.