### PR TITLE
 Improve mod compatibility for registerAlternativeDispenseBehavior 

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
@@ -64,9 +64,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 
-import static com.minecraftabnormals.abnormals_core.core.util.DataUtil.AlternativeDispenseBehavior;
-import static com.minecraftabnormals.abnormals_core.core.util.DataUtil.AlternativeDispenseBehavior.alternativeDispenseBehaviors;
-
 @Mod(AbnormalsCore.MODID)
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public final class AbnormalsCore {
@@ -155,7 +152,7 @@ public final class AbnormalsCore {
 	}
 
 	private void postLoadingSetup(FMLLoadCompleteEvent event) {
-		event.enqueueWork(() -> alternativeDispenseBehaviors().forEach(AlternativeDispenseBehavior::register));
+		event.enqueueWork(() -> DataUtil.AlternativeDispenseBehavior.alternativeDispenseBehaviors().forEach(DataUtil.AlternativeDispenseBehavior::register));
 	}
 
 	private void modelSetup(ModelRegistryEvent event) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
@@ -152,7 +152,7 @@ public final class AbnormalsCore {
 	}
 
 	private void postLoadingSetup(FMLLoadCompleteEvent event) {
-		event.enqueueWork(() -> DataUtil.AlternativeDispenseBehavior.alternativeDispenseBehaviors().forEach(DataUtil.AlternativeDispenseBehavior::register));
+		event.enqueueWork(() -> DataUtil.getSortedAlternativeDispenseBehaviors().forEach(DataUtil.AlternativeDispenseBehavior::register));
 	}
 
 	private void modelSetup(ModelRegistryEvent event) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
@@ -55,6 +55,7 @@ import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
@@ -62,6 +63,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
+
+import static com.minecraftabnormals.abnormals_core.core.util.DataUtil.AlternativeDispenseBehavior;
+import static com.minecraftabnormals.abnormals_core.core.util.DataUtil.AlternativeDispenseBehavior.alternativeDispenseBehaviors;
 
 @Mod(AbnormalsCore.MODID)
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -126,6 +130,7 @@ public final class AbnormalsCore {
 		});
 
 		modEventBus.addListener(EventPriority.LOWEST, this::commonSetup);
+		modEventBus.addListener(EventPriority.LOWEST, this::postLoadingSetup);
 		context.registerConfig(ModConfig.Type.COMMON, ACConfig.COMMON_SPEC);
 		context.registerConfig(ModConfig.Type.CLIENT, ACConfig.CLIENT_SPEC);
 	}
@@ -147,6 +152,10 @@ public final class AbnormalsCore {
 		ClientRegistry.bindTileEntityRenderer(ACTileEntities.SIGN.get(), SignTileEntityRenderer::new);
 
 		event.enqueueWork(SignManager::setupAtlas);
+	}
+
+	private void postLoadingSetup(FMLLoadCompleteEvent event) {
+		event.enqueueWork(() -> alternativeDispenseBehaviors().forEach(AlternativeDispenseBehavior::register));
 	}
 
 	private void modelSetup(ModelRegistryEvent event) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -303,6 +303,19 @@ public final class DataUtil {
 	}
 
 	/**
+	 * Please use {@link DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior)}
+	 * or {@link DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior, Function)}
+	 * instead.
+	 *
+	 * @see DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior)
+	 * @see DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior, Function)
+	 * */
+	@Deprecated
+	public static void registerAlternativeDispenseBehavior(Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior behavior) {
+		registerAlternativeDispenseBehavior("", item, condition, behavior, id -> 0);
+	}
+
+	/**
 	 * <p>Registers a {@link IDispenseItemBehavior} that will perform the new behavior if the condition is met and the behavior that was already in the registry if not.
 	 * This works even if multiple mods add new behavior to the same item, though it is possible that the conditions might
 	 * overlap, in which case {@link DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior, Function)}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -185,8 +185,7 @@ public final class DataUtil {
 	 * an {@link IDispenseItemBehavior} that performs the new behavior if its condition is met and the behavior that was 
 	 * already registered if not. See {@link AlternativeDispenseBehavior} for details.
 	 *
-	 * <p>Since Abnormals Core handles registering the condition at the right time, mods should call this method as early as possible,
-	 * such as in a {@code static{}} block.</p>
+	 * <p>Since Abnormals Core handles registering the condition at the right time, mods should call this method as early as possible.</p>
 	 *
 	 * @param behavior The {@link AlternativeDispenseBehavior} to be registered.  
 	 *

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -306,7 +306,7 @@ public final class DataUtil {
 	 * <p>Registers a {@link IDispenseItemBehavior} that will perform the new behavior if the condition is met and the behavior that was already in the registry if not.
 	 * This works even if multiple mods add new behavior to the same item, though it is possible that the conditions might
 	 * overlap, in which case {@link DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior, Function)}
-	 * should be used which allows you to specify mod ids whose conditions for the same item should be registered before or after to.
+	 * should be used.
 	 *
 	 * <p>Ideally, the condition should be implemented such that the predicate only passes if the new behavior will be 'successful', avoiding problems with failure sounds not playing.</p>
 	 *
@@ -317,6 +317,8 @@ public final class DataUtil {
 	 * @param item The {@link Item} to register {@code newBehavior} for.
 	 * @param condition A {@link BiPredicate} that takes in {@link IBlockSource} and {@link ItemStack} arguments, returning true if {@code newBehavior} should be used.
 	 * @param behavior The {@link IDispenseItemBehavior} that will be used if the {@code condition} is met.
+	 *
+	 * @see DataUtil#registerAlternativeDispenseBehavior(String, Item, BiPredicate, IDispenseItemBehavior, Function)
 	 *
 	 * @author abigailfails
 	 */

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -201,7 +201,8 @@ public final class DataUtil {
 	 * Please use {@link DataUtil#registerAlternativeDispenseBehavior(AlternativeDispenseBehavior)} instead.
 	 *
 	 * @see DataUtil#registerAlternativeDispenseBehavior(AlternativeDispenseBehavior)
-	 * */
+	 *
+	 */
 	@Deprecated
 	public static void registerAlternativeDispenseBehavior(Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior behavior) {
 		registerAlternativeDispenseBehavior(new AlternativeDispenseBehavior("", item, condition, behavior));
@@ -332,15 +333,16 @@ public final class DataUtil {
 
 	/**
 	 * When an instance of this class is registered using {@link DataUtil#registerAlternativeDispenseBehavior(AlternativeDispenseBehavior)},
-	 * an {@link IDispenseItemBehavior} will be registered that will perform a new {@link IDispenseItemBehavior} if
+	 * an {@link IDispenseItemBehavior} will get registered that will perform a new {@link IDispenseItemBehavior} if
 	 * a condition is met and the behavior that was already in the registry if not. See constructor for details.
 	 *
 	 * <p>This works even if multiple mods
-	 * add new behavior to the same item, though it is possible that the conditions might overlap, which is what
+	 * add new behavior to the same item, though the conditions may overlap, which is what
 	 * {@code modComparator} is intended to solve.</p>
 	 *
 	 * @author abigailfails
-	 * */
+	 *
+	 */
 	public static class AlternativeDispenseBehavior implements Comparable<AlternativeDispenseBehavior> {
 		protected final String modId;
 		protected final Item item;
@@ -349,18 +351,19 @@ public final class DataUtil {
 		protected final Comparator<String> modIdComparator;
 
 		/**
-		 * Initialises a new {@link AlternativeDispenseBehavior}, where {@code condition} decides whether {@code behavior}
-		 * should be used instead of the behavior previously stored in the dispenser registry for {@code item}.
+		 * Initialises a new {@link AlternativeDispenseBehavior} where {@code condition} decides whether {@code behavior}
+		 * should get used instead of the behavior previously stored in the dispenser registry for {@code item}.
 		 *
 		 * <p>Ideally, the condition should be implemented such that the predicate only passes if the new behavior will
 		 * be 'successful', avoiding problems with failure sounds not playing.</p>
 		 *
-		 * @param modId the ID of the mod registering the condition.
+		 * @param modId The ID of the mod registering the condition.
 		 * @param item The {@link Item} to register the {@code behavior} for.
 		 * @param condition A {@link BiPredicate} that takes in {@link IBlockSource} and {@link ItemStack} arguments, returning true if {@code behavior} should be performed.
 		 * @param behavior The {@link IDispenseItemBehavior} that will be used if the {@code condition} is met.
 		 *
-		 * */
+		 *
+		 */
 		public AlternativeDispenseBehavior(String modId, Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior behavior) {
 			this(modId, item, condition, behavior, (id1, id2) -> 0);
 		}
@@ -383,7 +386,7 @@ public final class DataUtil {
 		 * {@code a}'s. In this case, {@code a}'s {@code modComparator} should be something like
 		 * {@code (id1, id2) -> id2.equals("b") ? -1 : 0}, and {@code b}'s should be {@code (id1, id2) -> id2.equals("a") ? 1 : 0}.</p>
 		 *
-		 * @param modId the ID of the mod registering the condition.
+		 * @param modId The ID of the mod registering the condition.
 		 * @param item The {@link Item} to register the {@code behavior} for.
 		 * @param condition A {@link BiPredicate} that takes in {@link IBlockSource} and {@link ItemStack} arguments,
 		 *                  returning true if {@code behavior} should be performed.
@@ -393,7 +396,8 @@ public final class DataUtil {
 		 *                        It should return 1 if {@code behavior} is to be registered after the other behavior, -1 if
 		 *                        it should go before, and 0 in any other case.
 		 *
-		 * */
+		 *
+		 */
 		public AlternativeDispenseBehavior(String modId, Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior behavior, Comparator<String> modIdComparator) {
 			this.modId = modId;
 			this.item = item;

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -202,7 +202,6 @@ public final class DataUtil {
 	 * Please use {@link DataUtil#registerAlternativeDispenseBehavior(AlternativeDispenseBehavior)} instead.
 	 *
 	 * @see DataUtil#registerAlternativeDispenseBehavior(AlternativeDispenseBehavior)
-	 *
 	 */
 	@Deprecated
 	public static void registerAlternativeDispenseBehavior(Item item, BiPredicate<IBlockSource, ItemStack> condition, IDispenseItemBehavior behavior) {
@@ -337,7 +336,7 @@ public final class DataUtil {
 	 * internal use in order to register the behaviors to the dispenser registry.
 	 *
 	 * @author abigailfails
-	 * */
+	 */
 	public static List<AlternativeDispenseBehavior> getSortedAlternativeDispenseBehaviors() {
 		List<AlternativeDispenseBehavior> behaviors = new ArrayList<>(ALTERNATIVE_DISPENSE_BEHAVIORS);
 		Collections.sort(behaviors);
@@ -423,7 +422,7 @@ public final class DataUtil {
 		/**
 		 * Registers an {@link IDispenseItemBehavior} for {@code item} which performs {@code behavior} if
 		 * {@code condition} passes.
-		 * */
+		 */
 		public void register() {
 			IDispenseItemBehavior oldBehavior = DispenserBlock.DISPENSER_REGISTRY.get(item);
 			DispenserBlock.registerBehavior(item, (source, stack) -> condition.test(source, stack) ? behavior.dispense(source, stack) : oldBehavior.dispense(source, stack));


### PR DESCRIPTION
This PR delays the registry of alternative dispense behaviors until the end of mod loading, which should prevent compatability issues with mods like Quark. It also provides a new parameter that lets mods specifcy IDs whose conditions for the same item should be registered before or after theirs, making it easier for multiple mods to make their behaviors compatible with each other regardless of mod loading order.

I think the javadocs are bit wordy, as usual, so feel free to nitpick that !!!