### PR TITLE
Add a method to register custom note block instruments

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
@@ -23,6 +23,7 @@ import com.minecraftabnormals.abnormals_core.core.api.conditions.config.*;
 import com.minecraftabnormals.abnormals_core.core.api.model.FullbrightModel;
 import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
 import com.minecraftabnormals.abnormals_core.core.endimator.EndimationDataManager;
+import com.minecraftabnormals.abnormals_core.core.events.listener.ACEvents;
 import com.minecraftabnormals.abnormals_core.core.registry.ACEntities;
 import com.minecraftabnormals.abnormals_core.core.registry.ACLootConditions;
 import com.minecraftabnormals.abnormals_core.core.registry.ACTileEntities;
@@ -152,7 +153,10 @@ public final class AbnormalsCore {
 	}
 
 	private void postLoadingSetup(FMLLoadCompleteEvent event) {
-		event.enqueueWork(() -> DataUtil.getSortedAlternativeDispenseBehaviors().forEach(DataUtil.AlternativeDispenseBehavior::register));
+		event.enqueueWork(() -> {
+			DataUtil.getSortedAlternativeDispenseBehaviors().forEach(DataUtil.AlternativeDispenseBehavior::register);
+			ACEvents.SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS.addAll(DataUtil.getSortedCustomNoteBlockInstruments());
+		});
 	}
 
 	private void modelSetup(ModelRegistryEvent event) {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/AbnormalsCore.java
@@ -23,7 +23,7 @@ import com.minecraftabnormals.abnormals_core.core.api.conditions.config.*;
 import com.minecraftabnormals.abnormals_core.core.api.model.FullbrightModel;
 import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
 import com.minecraftabnormals.abnormals_core.core.endimator.EndimationDataManager;
-import com.minecraftabnormals.abnormals_core.core.events.listener.ACEvents;
+import com.minecraftabnormals.abnormals_core.core.events.CompatEvents;
 import com.minecraftabnormals.abnormals_core.core.registry.ACEntities;
 import com.minecraftabnormals.abnormals_core.core.registry.ACLootConditions;
 import com.minecraftabnormals.abnormals_core.core.registry.ACTileEntities;
@@ -155,7 +155,7 @@ public final class AbnormalsCore {
 	private void postLoadingSetup(FMLLoadCompleteEvent event) {
 		event.enqueueWork(() -> {
 			DataUtil.getSortedAlternativeDispenseBehaviors().forEach(DataUtil.AlternativeDispenseBehavior::register);
-			ACEvents.SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS.addAll(DataUtil.getSortedCustomNoteBlockInstruments());
+			CompatEvents.SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS = DataUtil.getSortedCustomNoteBlockInstruments();
 		});
 	}
 

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
@@ -5,6 +5,7 @@ import com.minecraftabnormals.abnormals_core.core.api.IAgeableEntity;
 import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
 import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.NetworkUtil;
+import net.minecraft.dispenser.IBlockSource;
 import net.minecraft.dispenser.ProxyBlockSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -81,8 +82,9 @@ public final class CompatEvents {
 			World world = (World) event.getWorld();
 			if (!world.isClientSide()) {
 				BlockPos pos = event.getPos();
+				IBlockSource source = new ProxyBlockSource((ServerWorld) world, pos.relative(Direction.DOWN));
 				for (DataUtil.CustomNoteBlockInstrument instrument : SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS) {
-					if (instrument.test(new ProxyBlockSource((ServerWorld) world, pos.relative(Direction.DOWN)))) {
+					if (instrument.test(source)) {
 						SoundEvent sound = instrument.getSound();
 						double note = event.getVanillaNoteId();
 						world.playSound(null, pos, sound, SoundCategory.RECORDS, 3.0F, (float) Math.pow(2.0D, (note - 12) / 12.0D));

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
@@ -1,4 +1,4 @@
-package com.minecraftabnormals.abnormals_core.core.events.listener;
+package com.minecraftabnormals.abnormals_core.core.events;
 
 import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
 import com.minecraftabnormals.abnormals_core.core.api.IAgeableEntity;
@@ -6,6 +6,7 @@ import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
 import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.NetworkUtil;
 import net.minecraft.block.BlockState;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -22,6 +23,7 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
@@ -35,15 +37,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * Events for mod compatibility.
+ *
  * @author abigailfails
  */
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID)
-public final class ACEvents {
+public final class CompatEvents {
 	public static final String POISON_TAG = AbnormalsCore.MODID + ":poisoned_by_potato";
-	public static List<DataUtil.CustomNoteBlockInstrument> SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS = new ArrayList<>();
+	public static List<DataUtil.CustomNoteBlockInstrument> SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS = null;
 
 	@SubscribeEvent
-	public static void onPlayerInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
+	public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
 		Entity target = event.getTarget();
 		ItemStack stack = event.getItemStack();
 		if (target instanceof IAgeableEntity && ((IAgeableEntity) target).hasGrowthProgress() && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
@@ -76,21 +80,21 @@ public final class ACEvents {
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void onNoteBlockPlay(NoteBlockEvent.Play event) {
-		BlockPos pos = event.getPos();
-		BlockState state = event.getWorld().getBlockState(pos.relative(Direction.DOWN));
-		for (DataUtil.CustomNoteBlockInstrument instrument : SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS) {
-			if (instrument.test(state)) {
-				SoundEvent sound = instrument.sound();
-				int note = event.getVanillaNoteId();
-				float f = (float) Math.pow(2.0D, (double) (note - 12) / 12.0D);
-				event.getWorld().playSound(null, pos, sound, SoundCategory.RECORDS, 3.0F, f);
-				if (!event.getWorld().isClientSide()) {
-					ResourceLocation noteKey = ForgeRegistries.PARTICLE_TYPES.getKey(ParticleTypes.NOTE);
-					if (noteKey != null)
-						NetworkUtil.spawnParticle(noteKey.toString(), pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, (double) note / 24.0D, 0.0D, 0.0D);
+		if (SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS  != null) {
+			IWorld world = event.getWorld();
+			BlockPos pos = event.getPos();
+			BlockState state = world.getBlockState(pos.relative(Direction.DOWN));
+			for (DataUtil.CustomNoteBlockInstrument instrument : SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS) {
+				if (instrument.test(state)) {
+					SoundEvent sound = instrument.sound();
+					double note = event.getVanillaNoteId();
+					world.playSound(null, pos, sound, SoundCategory.RECORDS, 3.0F, (float) Math.pow(2.0D, (note - 12) / 12.0D));
+					ResourceLocation noteId = ForgeRegistries.PARTICLE_TYPES.getKey(ParticleTypes.NOTE);
+					if (noteId != null)
+						NetworkUtil.spawnParticle(noteId.toString(), pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, note / 24.0D, 0.0D, 0.0D);
+					event.setCanceled(true);
+					break;
 				}
-				event.setCanceled(true);
-				break;
 			}
 		}
 

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
@@ -86,7 +86,7 @@ public final class CompatEvents {
 			BlockState state = world.getBlockState(pos.relative(Direction.DOWN));
 			for (DataUtil.CustomNoteBlockInstrument instrument : SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS) {
 				if (instrument.test(state)) {
-					SoundEvent sound = instrument.sound();
+					SoundEvent sound = instrument.getSound();
 					double note = event.getVanillaNoteId();
 					world.playSound(null, pos, sound, SoundCategory.RECORDS, 3.0F, (float) Math.pow(2.0D, (note - 12) / 12.0D));
 					ResourceLocation noteId = ForgeRegistries.PARTICLE_TYPES.getKey(ParticleTypes.NOTE);

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/CompatEvents.java
@@ -6,24 +6,21 @@ import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
 import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.NetworkUtil;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.particles.ParticleTypes;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IWorld;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
@@ -31,9 +28,7 @@ import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ForgeRegistries;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -44,6 +39,7 @@ import java.util.List;
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID)
 public final class CompatEvents {
 	public static final String POISON_TAG = AbnormalsCore.MODID + ":poisoned_by_potato";
+	public static final String NOTE_KEY = "minecraft:note";
 	public static List<DataUtil.CustomNoteBlockInstrument> SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS = null;
 
 	@SubscribeEvent
@@ -81,7 +77,7 @@ public final class CompatEvents {
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void onNoteBlockPlay(NoteBlockEvent.Play event) {
 		if (SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS  != null) {
-			IWorld world = event.getWorld();
+			World world = (World) event.getWorld();
 			BlockPos pos = event.getPos();
 			BlockState state = world.getBlockState(pos.relative(Direction.DOWN));
 			for (DataUtil.CustomNoteBlockInstrument instrument : SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS) {
@@ -89,9 +85,7 @@ public final class CompatEvents {
 					SoundEvent sound = instrument.getSound();
 					double note = event.getVanillaNoteId();
 					world.playSound(null, pos, sound, SoundCategory.RECORDS, 3.0F, (float) Math.pow(2.0D, (note - 12) / 12.0D));
-					ResourceLocation noteId = ForgeRegistries.PARTICLE_TYPES.getKey(ParticleTypes.NOTE);
-					if (noteId != null)
-						NetworkUtil.spawnParticle(noteId.toString(), pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, note / 24.0D, 0.0D, 0.0D);
+					NetworkUtil.spawnParticle(NOTE_KEY, world.dimension(), pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, note / 24.0D, 0.0D, 0.0D);
 					event.setCanceled(true);
 					break;
 				}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/events/listener/ACEvents.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/events/listener/ACEvents.java
@@ -1,35 +1,49 @@
-package com.minecraftabnormals.abnormals_core.core.events;
+package com.minecraftabnormals.abnormals_core.core.events.listener;
 
 import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
 import com.minecraftabnormals.abnormals_core.core.api.IAgeableEntity;
 import com.minecraftabnormals.abnormals_core.core.config.ACConfig;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
+import com.minecraftabnormals.abnormals_core.core.util.NetworkUtil;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.particles.ParticleTypes;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.world.NoteBlockEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Events for mod compatibility.
- *
  * @author abigailfails
  */
 @Mod.EventBusSubscriber(modid = AbnormalsCore.MODID)
-public final class CompatEvents {
+public final class ACEvents {
 	public static final String POISON_TAG = AbnormalsCore.MODID + ":poisoned_by_potato";
+	public static List<DataUtil.CustomNoteBlockInstrument> SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS = new ArrayList<>();
 
 	@SubscribeEvent
-	public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
+	public static void onPlayerInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
 		Entity target = event.getTarget();
 		ItemStack stack = event.getItemStack();
 		if (target instanceof IAgeableEntity && ((IAgeableEntity) target).hasGrowthProgress() && stack.getItem() == Items.POISONOUS_POTATO && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
@@ -58,5 +72,27 @@ public final class CompatEvents {
 		if (entity instanceof IAgeableEntity && ACConfig.ValuesHolder.isPoisonPotatoCompatEnabled() && ModList.get().isLoaded("quark")) {
 			if (entity.getPersistentData().getBoolean(POISON_TAG)) ((IAgeableEntity) entity).resetGrowthProgress();
 		}
+	}
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public static void onNoteBlockPlay(NoteBlockEvent.Play event) {
+		BlockPos pos = event.getPos();
+		BlockState state = event.getWorld().getBlockState(pos.relative(Direction.DOWN));
+		for (DataUtil.CustomNoteBlockInstrument instrument : SORTED_CUSTOM_NOTE_BLOCK_INSTRUMENTS) {
+			if (instrument.test(state)) {
+				SoundEvent sound = instrument.sound();
+				int note = event.getVanillaNoteId();
+				float f = (float) Math.pow(2.0D, (double) (note - 12) / 12.0D);
+				event.getWorld().playSound(null, pos, sound, SoundCategory.RECORDS, 3.0F, f);
+				if (!event.getWorld().isClientSide()) {
+					ResourceLocation noteKey = ForgeRegistries.PARTICLE_TYPES.getKey(ParticleTypes.NOTE);
+					if (noteKey != null)
+						NetworkUtil.spawnParticle(noteKey.toString(), pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, (double) note / 24.0D, 0.0D, 0.0D);
+				}
+				event.setCanceled(true);
+				break;
+			}
+		}
+
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -475,9 +475,9 @@ public final class DataUtil {
 	 */
 	public static class CustomNoteBlockInstrument implements Comparable<CustomNoteBlockInstrument> {
 		protected final String modId;
-		protected final Predicate<BlockState> condition;
-		protected final SoundEvent sound;
 		protected final Comparator<String> modIdComparator;
+		protected final Predicate<BlockState> condition;
+		public final SoundEvent sound;
 
 		/**
 		 * Initialises a new {@link CustomNoteBlockInstrument} where {@code condition} decides whether {@code sound}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -477,7 +477,7 @@ public final class DataUtil {
 		protected final String modId;
 		protected final Comparator<String> modIdComparator;
 		protected final Predicate<BlockState> condition;
-		public final SoundEvent sound;
+		private final SoundEvent sound;
 
 		/**
 		 * Initialises a new {@link CustomNoteBlockInstrument} where {@code condition} decides whether {@code sound}

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -213,7 +213,7 @@ public final class DataUtil {
 
 	/**
 	 * Registers a {@link CustomNoteBlockInstrument} that will get used to play a custom note block sound if a
-	 * {@link BlockState} predicate (representing the position under the note block) passes.
+	 * {@link IBlockSource} predicate (representing the position under the note block) passes.
 	 * See {@link CustomNoteBlockInstrument} for details.
 	 *
 	 * <p>Since Abnormals Core adds instruments to an internal list at the end of mod loading, mods should call
@@ -466,7 +466,7 @@ public final class DataUtil {
 	/**
 	 * When an instance of this class is registered using
 	 * {@link DataUtil#registerNoteBlockInstrument(CustomNoteBlockInstrument)}, note blocks will play a custom sound
-	 * if a blockstate predicate for the position under the note block passes. See constructor for details.
+	 * if an {@link IBlockSource} predicate for the position under the note block passes. See constructor for details.
 	 *
 	 * <p>If multiple mods add new instruments the predicates may overlap, which is what
 	 * {@code modIdComparator} is intended to solve.</p>
@@ -476,7 +476,7 @@ public final class DataUtil {
 	public static class CustomNoteBlockInstrument implements Comparable<CustomNoteBlockInstrument> {
 		protected final String modId;
 		protected final Comparator<String> modIdComparator;
-		protected final Predicate<BlockState> condition;
+		protected final Predicate<IBlockSource> condition;
 		private final SoundEvent sound;
 
 		/**
@@ -484,11 +484,11 @@ public final class DataUtil {
 		 * should get played instead of vanilla's when a note block is triggered.
 		 *
 		 * @param modId The ID of the mod registering the condition.
-		 * @param condition A {@link Predicate} that takes in a {@link BlockState} instance that represents the position
-		 *                  under the note block, returning true if {@code sound} should be played.
+		 * @param condition A {@link Predicate} that takes in a {@link IBlockSource} instance that represents the
+		 *                  position under the note block, returning true if {@code sound} should be played.
 		 * @param sound The {@link SoundEvent} that will be played if {@code condition} is met.
 		 */
-		public CustomNoteBlockInstrument(String modId, Predicate<BlockState> condition, SoundEvent sound){
+		public CustomNoteBlockInstrument(String modId, Predicate<IBlockSource> condition, SoundEvent sound){
 			this(modId, condition, sound, (id1, id2) -> 0);
 		}
 
@@ -496,7 +496,7 @@ public final class DataUtil {
 		 * Initialises a new {@link CustomNoteBlockInstrument} where {@code condition} decides whether {@code sound}
 		 * should get played instead of vanilla's when a note block is triggered.
 		 *
-		 * <p>If multiple mods add new instruments and the {@link BlockState} predicates overlap such that the order
+		 * <p>If multiple mods add new instruments and the {@link IBlockSource} predicates overlap such that the order
 		 * that they are registered in matters, {@code modIdComparator} (where the first parameter is {@code modId} and
 		 * the second parameter is the mod ID of another {@link CustomNoteBlockInstrument} instance) can be used to
 		 * ensure this order regardless of which mod is loaded first.</p>
@@ -509,15 +509,15 @@ public final class DataUtil {
 		 * {@code (id1, id2) -> id2.equals("a") ? -1 : 0}.</p>
 		 *
 		 * @param modId The ID of the mod registering the condition.
-		 * @param condition A {@link Predicate} that takes in a {@link BlockState} predicate, returning true if
-		 * 					{@code sound} should be played.
+		 * @param condition A {@link Predicate} that takes in a {@link IBlockSource} instance that represents the
+		 *                  position under the note block, returning true if {@code sound} should be played.
 		 * @param sound The {@link SoundEvent} that will be played if {@code condition} is met.
 		 * @param modIdComparator A {@link Comparator} that compares two strings. The first is {@code modId}, and the
 		 *                        second is the mod id for another note block instrument.
 		 *                        It should return 1 if {@code condition} should be tested after the other instrument's,
 		 *                        -1 if it should go before, and 0 in any other case.
 		 */
-		public CustomNoteBlockInstrument(String modId, Predicate<BlockState> condition, SoundEvent sound, Comparator<String> modIdComparator){
+		public CustomNoteBlockInstrument(String modId, Predicate<IBlockSource> condition, SoundEvent sound, Comparator<String> modIdComparator){
 			this.modId = modId;
 			this.condition = condition;
 			this.sound = sound;
@@ -529,8 +529,8 @@ public final class DataUtil {
 			return this.modIdComparator.compare(this.modId, instrument.modId);
 		}
 
-		public boolean test(BlockState state) {
-			return this.condition.test(state);
+		public boolean test(IBlockSource source) {
+			return this.condition.test(source);
 		}
 
 		public SoundEvent getSound() {

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -384,7 +384,7 @@ public final class DataUtil {
 	 *
 	 * <p>This works even if multiple mods
 	 * add new behavior to the same item, though the conditions may overlap, which is what
-	 * {@code modComparator} is intended to solve.</p>
+	 * {@code modIdComparator} is intended to solve.</p>
 	 *
 	 * @author abigailfails
 	 */
@@ -427,7 +427,7 @@ public final class DataUtil {
 		 * <p>For example, if a mod with the ID {@code a} has a behavior where its condition passes if any block is in front
 		 * of the dispenser, but a mod with the ID {@code b} has a behavior for the same item that passes only if a specific
 		 * block is in front of the dispenser, authors may want to make sure that {@code b}'s condition is registered after
-		 * {@code a}'s. In this case, {@code a}'s {@code modComparator} should be something like
+		 * {@code a}'s. In this case, {@code a}'s {@code modIdComparator} should be something like
 		 * {@code (id1, id2) -> id2.equals("b") ? -1 : 0}, and {@code b}'s should be {@code (id1, id2) -> id2.equals("a") ? 1 : 0}.</p>
 		 *
 		 * @param modId The ID of the mod registering the condition.
@@ -450,7 +450,7 @@ public final class DataUtil {
 
 		@Override
 		public int compareTo(AlternativeDispenseBehavior behavior) {
-			return this.item == behavior.item ? modIdComparator.compare(this.modId, behavior.modId) : 0;
+			return this.item == behavior.item ? this.modIdComparator.compare(this.modId, behavior.modId) : 0;
 		}
 
 		/**

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/DataUtil.java
@@ -23,6 +23,7 @@ import net.minecraft.potion.PotionBrewing;
 import net.minecraft.util.IItemProvider;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.Util;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.WorldGenRegistries;
@@ -45,10 +46,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 public final class DataUtil {
 	private static final Method ADD_MIX_METHOD = ObfuscationReflectionHelper.findMethod(PotionBrewing.class, "func_193357_a", Potion.class, Item.class, Potion.class);
 	private static final Vector<AlternativeDispenseBehavior> ALTERNATIVE_DISPENSE_BEHAVIORS = new Vector<>();
+	private static final Vector<CustomNoteBlockInstrument> CUSTOM_NOTE_BLOCK_INSTRUMENTS = new Vector<>();
 
 	public static void registerFlammable(Block block, int encouragement, int flammability) {
 		FireBlock fire = (FireBlock) Blocks.FIRE;
@@ -209,6 +212,25 @@ public final class DataUtil {
 	}
 
 	/**
+	 * Registers a {@link CustomNoteBlockInstrument} that will be used to play a custom note block sound if a
+	 * {@link BlockState} predicate (representing the position under the note block) passes.
+	 * See {@link CustomNoteBlockInstrument} for details.
+	 *
+	 * <p>Since Abnormals Core adds instruments to an internal list at the end of mod loading, mods should call
+	 * this method as early as possible, ideally in an
+	 * {@link net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent FMLCommonSetupEvent}.</p>
+	 *
+	 * @param instrument The {@link CustomNoteBlockInstrument} to be registered.
+	 *
+	 * @see CustomNoteBlockInstrument
+	 *
+	 * @author abigailfails
+	 * */
+	public static void registerNoteBlockInstrument(CustomNoteBlockInstrument instrument) {
+		CUSTOM_NOTE_BLOCK_INSTRUMENTS.add(instrument);
+	}
+
+	/**
 	 * Adds a new {@link JigsawPiece} to a pre-existing {@link JigsawPattern}.
 	 *
 	 * @param toAdd The {@link ResourceLocation} of the pattern to insert the new piece into.
@@ -344,6 +366,18 @@ public final class DataUtil {
 	}
 
 	/**
+	 * Returns the list of registered {@link CustomNoteBlockInstrument}s, sorted by their comparators. Intended for
+	 * internal use.
+	 *
+	 * @author abigailfails
+	 */
+	public static List<CustomNoteBlockInstrument> getSortedCustomNoteBlockInstruments() {
+		List<CustomNoteBlockInstrument> instruments = new ArrayList<>(CUSTOM_NOTE_BLOCK_INSTRUMENTS);
+		Collections.sort(instruments);
+		return instruments;
+	}
+
+	/**
 	 * When an instance of this class is registered using {@link DataUtil#registerAlternativeDispenseBehavior(AlternativeDispenseBehavior)},
 	 * an {@link IDispenseItemBehavior} will get registered that will perform a new {@link IDispenseItemBehavior} if
 	 * a condition is met and the behavior that was already in the registry if not. See constructor for details.
@@ -426,6 +460,81 @@ public final class DataUtil {
 		public void register() {
 			IDispenseItemBehavior oldBehavior = DispenserBlock.DISPENSER_REGISTRY.get(item);
 			DispenserBlock.registerBehavior(item, (source, stack) -> condition.test(source, stack) ? behavior.dispense(source, stack) : oldBehavior.dispense(source, stack));
+		}
+	}
+
+	/**
+	 * When an instance of this class is registered using
+	 * {@link DataUtil#registerNoteBlockInstrument(CustomNoteBlockInstrument)}, note blocks will play a custom sound
+	 * if a blockstate predicate for the position under the note block passes. See constructor for details.
+	 *
+	 * <p>If multiple mods add new instruments the predicates may overlap, which is what
+	 * {@code modIdComparator} is intended to solve.</p>
+	 *
+	 * @author abigailfails
+	 */
+	public static class CustomNoteBlockInstrument implements Comparable<CustomNoteBlockInstrument> {
+		protected final String modId;
+		protected final Predicate<BlockState> condition;
+		protected final SoundEvent sound;
+		protected final Comparator<String> modIdComparator;
+
+		/**
+		 * Initialises a new {@link CustomNoteBlockInstrument} where {@code condition} decides whether {@code sound}
+		 * should get played instead of vanilla's when a note block is triggered.
+		 *
+		 * @param modId The ID of the mod registering the condition.
+		 * @param condition A {@link Predicate} that takes in a {@link BlockState} instance that represents the position
+		 *                  under the note block, returning true if {@code sound} should be played.
+		 * @param sound The {@link SoundEvent} that will be played if {@code condition} is met.
+		 */
+		public CustomNoteBlockInstrument(String modId, Predicate<BlockState> condition, SoundEvent sound){
+			this(modId, condition, sound, (id1, id2) -> 0);
+		}
+
+		/**
+		 * Initialises a new {@link CustomNoteBlockInstrument} where {@code condition} decides whether {@code sound}
+		 * should get played instead of vanilla's when a note block is triggered.
+		 *
+		 * <p>If multiple mods add new instruments and the {@link BlockState} predicates overlap such that the order
+		 * that they are registered in matters, {@code modIdComparator} (where the first parameter is {@code modId} and
+		 * the second parameter is the mod ID of another {@link CustomNoteBlockInstrument} instance) can be used to
+		 * ensure this order regardless of which mod is loaded first.</p>
+		 *
+		 * <p>For example, if a mod with the ID {@code a} has an instrument that plays if the block under the note
+		 * block's material is {@code HEAVY_METAL}, but a mod with the ID {@code b} has an instrument that plays if the
+		 * block is a lodestone, authors may want to make sure that {@code b}'s condition is tested before {@code a}'s.
+		 * In this case, {@code a}'s {@code modIdComparator} should be something like
+		 * {@code (id1, id2) -> id2.equals("b") ? 1 : 0}, and {@code b}'s should be
+		 * {@code (id1, id2) -> id2.equals("a") ? -1 : 0}.</p>
+		 *
+		 * @param modId The ID of the mod registering the condition.
+		 * @param condition A {@link Predicate} that takes in a {@link BlockState} predicate, returning true if
+		 * 					{@code sound} should be played.
+		 * @param sound The {@link SoundEvent} that will be played if {@code condition} is met.
+		 * @param modIdComparator A {@link Comparator} that compares two strings. The first is {@code modId}, and the
+		 *                        second is the mod id for another note block instrument.
+		 *                        It should return 1 if {@code condition} should be tested after the other instrument's,
+		 *                        -1 if it should go before, and 0 in any other case.
+		 */
+		public CustomNoteBlockInstrument(String modId, Predicate<BlockState> condition, SoundEvent sound, Comparator<String> modIdComparator){
+			this.modId = modId;
+			this.condition = condition;
+			this.sound = sound;
+			this.modIdComparator = modIdComparator;
+		}
+
+		@Override
+		public int compareTo(CustomNoteBlockInstrument instrument) {
+			return this.modIdComparator.compare(this.modId, instrument.modId);
+		}
+
+		public boolean test(BlockState state) {
+			return this.condition.test(state);
+		}
+
+		public SoundEvent sound() {
+			return this.sound;
 		}
 	}
 }

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/NetworkUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/NetworkUtil.java
@@ -34,7 +34,7 @@ public final class NetworkUtil {
 	/**
 	 * All other parameters work same as world#addParticle
 	 * <p>Used for adding particles to client worlds from the server side</p>
-	 * @param name - The registry name of the particle
+	 * @param name The registry name of the particle
 	 */
 	public static void spawnParticle(String name, double posX, double posY, double posZ, double motionX, double motionY, double motionZ) {
 		AbnormalsCore.CHANNEL.send(PacketDistributor.ALL.with(() -> null), new MessageS2CSpawnParticle(name, posX, posY, posZ, motionX, motionY, motionZ));
@@ -45,8 +45,8 @@ public final class NetworkUtil {
 	 * <p>Used for adding particles to client worlds from the server side</p>
 	 * <p>Only sends the packet to players in {@code dimension}</p>
 	 *
-	 * @param name - The registry name of the particle
-	 * @param dimension - The dimension to spawn the particle in. You can get this using {@link World#dimension()}
+	 * @param name The registry name of the particle
+	 * @param dimension The dimension to spawn the particle in. You can get this using {@link World#dimension()}
 	 */
 	public static void spawnParticle(String name, RegistryKey<World> dimension, double posX, double posY, double posZ, double motionX, double motionY, double motionZ) {
 		AbnormalsCore.CHANNEL.send(PacketDistributor.DIMENSION.with(() -> dimension), new MessageS2CSpawnParticle(name, posX, posY, posZ, motionX, motionY, motionZ));
@@ -55,10 +55,10 @@ public final class NetworkUtil {
 	/**
 	 * Teleports the entity to a specified location
 	 *
-	 * @param entity - The Entity to teleport
-	 * @param posX   - The x position
-	 * @param posY   - The y position
-	 * @param posZ   - The z position
+	 * @param entity The Entity to teleport
+	 * @param posX   The x position
+	 * @param posY   The y position
+	 * @param posZ   The z position
 	 */
 	public static void teleportEntity(Entity entity, double posX, double posY, double posZ) {
 		entity.moveTo(posX, posY, posZ, entity.yRot, entity.xRot);
@@ -68,8 +68,8 @@ public final class NetworkUtil {
 	/**
 	 * Sends an animation message to the clients to update an entity's animations
 	 *
-	 * @param entity           - The Entity to send the packet for
-	 * @param endimationToPlay - The endimation to play
+	 * @param entity           The Entity to send the packet for
+	 * @param endimationToPlay The endimation to play
 	 */
 	public static <E extends Entity & IEndimatedEntity> void setPlayingAnimationMessage(E entity, Endimation endimationToPlay) {
 		if (!entity.level.isClientSide) {
@@ -81,7 +81,7 @@ public final class NetworkUtil {
 	/**
 	 * Send a packet to the client to redirect them to another server
 	 *
-	 * @param address - The address to connect to
+	 * @param address The address to connect to
 	 */
 	public static void redirectToServer(ServerPlayerEntity player, String address) {
 		AbnormalsCore.CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), new MessageS2CServerRedirect(address));
@@ -90,7 +90,7 @@ public final class NetworkUtil {
 	/**
 	 * Send a packet to all clients to redirect them to another server
 	 *
-	 * @param address - The address to connect to
+	 * @param address The address to connect to
 	 */
 	public static void redirectAllToServer(String address) {
 		AbnormalsCore.CHANNEL.send(PacketDistributor.ALL.noArg(), new MessageS2CServerRedirect(address));

--- a/src/main/java/com/minecraftabnormals/abnormals_core/core/util/NetworkUtil.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_core/core/util/NetworkUtil.java
@@ -16,6 +16,7 @@ import net.minecraft.client.gui.screen.*;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.RegistryKey;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
@@ -32,11 +33,23 @@ import java.util.Set;
 public final class NetworkUtil {
 	/**
 	 * All other parameters work same as world#addParticle
-	 * Used for adding particles to client worlds from the server side
+	 * <p>Used for adding particles to client worlds from the server side</p>
 	 * @param name - The registry name of the particle
 	 */
 	public static void spawnParticle(String name, double posX, double posY, double posZ, double motionX, double motionY, double motionZ) {
 		AbnormalsCore.CHANNEL.send(PacketDistributor.ALL.with(() -> null), new MessageS2CSpawnParticle(name, posX, posY, posZ, motionX, motionY, motionZ));
+	}
+
+	/**
+	 * All other parameters work same as world#addParticle
+	 * <p>Used for adding particles to client worlds from the server side</p>
+	 * <p>Only sends the packet to players in {@code dimension}</p>
+	 *
+	 * @param name - The registry name of the particle
+	 * @param dimension - The dimension to spawn the particle in. You can get this using {@link World#dimension()}
+	 */
+	public static void spawnParticle(String name, RegistryKey<World> dimension, double posX, double posY, double posZ, double motionX, double motionY, double motionZ) {
+		AbnormalsCore.CHANNEL.send(PacketDistributor.DIMENSION.with(() -> dimension), new MessageS2CSpawnParticle(name, posX, posY, posZ, motionX, motionY, motionZ));
 	}
 
 	/**

--- a/src/test/java/core/ACTest.java
+++ b/src/test/java/core/ACTest.java
@@ -96,8 +96,8 @@ public final class ACTest {
 			EntitySpawnPlacementRegistry.register(TestEntities.COW.get(), EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING, CowEntity::checkAnimalSpawnRules);
 		});
 
-		DataUtil.registerNoteBlockInstrument(new DataUtil.CustomNoteBlockInstrument(AbnormalsCore.MODID, state -> state.getMaterial() == Material.HEAVY_METAL, SoundEvents.BELL_BLOCK));
-		DataUtil.registerNoteBlockInstrument(new DataUtil.CustomNoteBlockInstrument(ACTest.MOD_ID, state -> state.is(Blocks.LODESTONE), SoundEvents.SHIELD_BREAK, (id1, id2) -> id2.equals("abnormals_core") ? -1 : 0));
+		DataUtil.registerNoteBlockInstrument(new DataUtil.CustomNoteBlockInstrument(AbnormalsCore.MODID, source -> source.getBlockState().getMaterial() == Material.HEAVY_METAL, SoundEvents.BELL_BLOCK));
+		DataUtil.registerNoteBlockInstrument(new DataUtil.CustomNoteBlockInstrument(ACTest.MOD_ID, source -> source.getBlockState().is(Blocks.LODESTONE), SoundEvents.SHIELD_BREAK, (id1, id2) -> id2.equals("abnormals_core") ? -1 : 0));
 
 		BiomeModificationManager instance = BiomeModificationManager.INSTANCE;
 		instance.addModifier(BiomeFeatureModifier.createFeatureAdder(BiomeModificationPredicates.forBiomeKey(Biomes.PLAINS), GenerationStage.Decoration.VEGETAL_DECORATION, () -> Features.BIRCH.decorated(Placement.DARK_OAK_TREE.configured(IPlacementConfig.NONE))));

--- a/src/test/java/core/ACTest.java
+++ b/src/test/java/core/ACTest.java
@@ -10,9 +10,11 @@ import com.minecraftabnormals.abnormals_core.common.world.storage.GlobalStorage;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.DataProcessors;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.TrackedData;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.TrackedDataManager;
+import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
 import com.minecraftabnormals.abnormals_core.core.annotations.Test;
 import com.minecraftabnormals.abnormals_core.core.registry.LootInjectionRegistry;
 import com.minecraftabnormals.abnormals_core.core.util.BiomeUtil;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.mojang.datafixers.util.Pair;
 import common.world.TestGlobalStorage;
@@ -20,12 +22,15 @@ import core.registry.TestBiomes;
 import core.registry.TestEntities;
 import core.registry.TestFeatures;
 import core.registry.TestItems;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.entity.CowRenderer;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntitySpawnPlacementRegistry;
 import net.minecraft.entity.passive.CowEntity;
 import net.minecraft.loot.LootTables;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvents;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.GenerationStage;
@@ -90,6 +95,9 @@ public final class ACTest {
 			BiomeUtil.addNetherBiome(new Biome.Attributes(0.0F, 0.1F, 0.0F, 0.0F, 0.25F), TestBiomes.TEST_NETHER.getKey());
 			EntitySpawnPlacementRegistry.register(TestEntities.COW.get(), EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING, CowEntity::checkAnimalSpawnRules);
 		});
+
+		DataUtil.registerNoteBlockInstrument(new DataUtil.CustomNoteBlockInstrument(AbnormalsCore.MODID, state -> state.getMaterial() == Material.HEAVY_METAL, SoundEvents.BELL_BLOCK));
+		DataUtil.registerNoteBlockInstrument(new DataUtil.CustomNoteBlockInstrument(ACTest.MOD_ID, state -> state.is(Blocks.LODESTONE), SoundEvents.SHIELD_BREAK, (id1, id2) -> id2.equals("abnormals_core") ? -1 : 0));
 
 		BiomeModificationManager instance = BiomeModificationManager.INSTANCE;
 		instance.addModifier(BiomeFeatureModifier.createFeatureAdder(BiomeModificationPredicates.forBiomeKey(Biomes.PLAINS), GenerationStage.Decoration.VEGETAL_DECORATION, () -> Features.BIRCH.decorated(Placement.DARK_OAK_TREE.configured(IPlacementConfig.NONE))));


### PR DESCRIPTION
This PR makes it easier to add custom note block instruments by handling all the sound and particle stuff internally so that mods only need to provide a `BlockState` predicate and a `SoundEvent`. I also fixed an incorrectly named parameter in the javadocs from my last PR.